### PR TITLE
Improve timeout handling in sync backend

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - pip install --disable-pip-version-check --user --upgrade pip wheel
+  - pip install --disable-pip-version-check --user --upgrade pip~=9.0 wheel
   - pip install tox virtualenv
 
 test_script:

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -305,7 +305,7 @@ class TestSOCKS5Proxy(IPV4SocketDummyServerTestCase):
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
-    @pytest.mark.xfail
+    @pytest.mark.skip
     def test_connection_timeouts(self):
         event = threading.Event()
 

--- a/test/test_sync_connection.py
+++ b/test/test_sync_connection.py
@@ -250,8 +250,7 @@ class TestUnusualSocketConditions(unittest.TestCase):
         conn = HTTP1Connection('localhost', 80)
         sock = ScenarioSocket(scenario)
         selector = ScenarioSelector(scenario, sock)
-        sync_socket = SyncSocket(
-            sock, read_timeout=self.READ_TIMEOUT, _selector=selector)
+        sync_socket = SyncSocket(sock, _selector=selector)
         conn._sock = sync_socket
 
         request = Request(method=b'GET', target=b'/')

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -49,7 +49,6 @@ def wait_for_socket(ready_event):
 
 class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
-    @pytest.mark.skip
     def test_timeout_float(self):
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
@@ -66,7 +65,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         block_event.set()  # Pre-release block
         pool.request('GET', '/')
 
-    @pytest.mark.skip
     def test_conn_closed(self):
         block_event = Event()
         self.start_basic_handler(block_send=block_event, num=1)
@@ -86,7 +84,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
 
         block_event.set()
 
-    @pytest.mark.skip
+    @pytest.mark.xfail
     def test_timeout(self):
         # Requests should time out when expected
         block_event = Event()
@@ -147,7 +145,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
                           timeout=SHORT_TIMEOUT)
         block_event.set()  # Release request
 
-    @pytest.mark.skip
     def test_connect_timeout(self):
         url = '/'
         host, port = TARPIT_HOST, 80
@@ -176,7 +173,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         pool._put_conn(conn)
         self.assertRaises(ConnectTimeoutError, pool.request, 'GET', url, timeout=timeout)
 
-    @pytest.mark.skip
     def test_total_applies_connect(self):
         host, port = TARPIT_HOST, 80
 
@@ -194,7 +190,6 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         self.addCleanup(conn.close)
         self.assertRaises(ConnectTimeoutError, pool._make_request, conn, 'GET', '/')
 
-    @pytest.mark.skip
     def test_total_timeout(self):
         block_event = Event()
         ready_event = self.start_basic_handler(block_send=block_event, num=2)
@@ -216,7 +211,9 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         self.addCleanup(pool.close)
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/')
 
-    @pytest.mark.xfail
+    # Sometimes fails with `AttributeError: 'TestConnectionPoolTimeouts' object
+    # has no attribute 'port'` when instantiating the pool
+    @pytest.mark.skip
     def test_create_connection_timeout(self):
         timeout = Timeout(connect=SHORT_TIMEOUT, total=LONG_TIMEOUT)
         pool = HTTPConnectionPool(TARPIT_HOST, self.port, timeout=timeout, retries=False)

--- a/urllib3/_backends/trio_backend.py
+++ b/urllib3/_backends/trio_backend.py
@@ -6,8 +6,8 @@ BUFSIZE = 65536
 
 
 class TrioBackend:
-    async def connect(
-            self, host, port, source_address=None, socket_options=None):
+    async def connect(self, host, port, connect_timeout,
+                      source_address=None, socket_options=None):
         if source_address is not None:
             # You can't really combine source_address= and happy eyeballs
             # (can we get rid of source_address? or at least make it a source
@@ -44,7 +44,8 @@ class TrioSocket:
     async def receive_some(self):
         return await self._stream.receive_some(BUFSIZE)
 
-    async def send_and_receive_for_a_while(self, produce_bytes, consume_bytes):
+    async def send_and_receive_for_a_while(
+            self, produce_bytes, consume_bytes, read_timeout):
         async def sender():
             while True:
                 outgoing = await produce_bytes()

--- a/urllib3/_backends/twisted_backend.py
+++ b/urllib3/_backends/twisted_backend.py
@@ -18,7 +18,8 @@ class TwistedBackend:
     def __init__(self, reactor):
         self._reactor = reactor
 
-    async def connect(self, host, port, source_address=None, socket_options=None):
+    async def connect(self, host, port, connect_timeout,
+                      source_address=None, socket_options=None):
         # HostnameEndpoint only supports setting source host, not source port
         if source_address is not None:
             raise NotImplementedError(
@@ -188,7 +189,8 @@ class TwistedSocket:
     async def receive_some(self):
         return await self._protocol.receive_some()
 
-    async def send_and_receive_for_a_while(self, produce_bytes, consume_bytes):
+    async def send_and_receive_for_a_while(
+            self, produce_bytes, consume_bytes, read_timeout):
         async def sender():
             while True:
                 outgoing = await produce_bytes()


### PR DESCRIPTION
urllib3 has quite an elaborate scheme to handle timeouts. None of that
is needed for trio, but it's needed for the sync version (and possibly
for other async frameworks, I'm not sure).

Anyway, we have a connect timeout (possibly set for each connection) and
a read timeout (possibly set for each request). The
connectionpool/request code takes care of sending the correct values to
each connection, what's left is passing this down to the backend and
making sure the backend handles that correctly.

Until now, both timeouts (connect and read) had issues because they were
set at backend creation time, which is too early. We now:

* add connect_timeout as a parameter to connect()
* add read_timeout as a parameter to send_request()