### PR TITLE
move _sync codegen to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,12 @@ commands=
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
     pip install .[socks,secure]
+    # Generate _sync module
+    # XX Note this is a temporary hack until https://github.com/python-trio/urllib3/issues/29 is fixed
+    python setup.py build
+    rm -rf urllib3/_sync
+    cp -r build/lib/urllib3/_sync urllib3/_sync
+    # Run the tests
     py.test --cov urllib3 test {posargs}
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning


### PR DESCRIPTION
This appears to allow me to run the tests without messing around with virtualenv's a la the `runtests.py` script.