### PR TITLE
Honor read timeouts

### DIFF
--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -398,11 +398,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 self, url, "Read timed out. (read timeout=%s)" % read_timeout)
         if read_timeout is Timeout.DEFAULT_TIMEOUT:
             read_timeout = socket.getdefaulttimeout()
+        conn.read_timeout = read_timeout
 
         # Receive the response from the server
         try:
-            response = await conn.send_request(
-                request, read_timeout=read_timeout)
+            response = await conn.send_request(request, read_timeout=read_timeout)
         except (SocketTimeout, BaseSSLError, SocketError) as e:
             self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
             raise

--- a/src/urllib3/_backends/sync_backend.py
+++ b/src/urllib3/_backends/sync_backend.py
@@ -42,11 +42,11 @@ class SyncSocket(object):
     def getpeercert(self, binary_form=False):
         return self._sock.getpeercert(binary_form=binary_form)
 
-    def _wait(self, readable, writable, read_timeout=None):
+    def _wait(self, readable, writable, timeout=None):
         assert readable or writable
         if not self._wait_for_socket(
                 self._sock, read=readable, write=writable,
-                timeout=read_timeout):
+                timeout=timeout):
             raise socket.timeout()  # XX use a backend-agnostic exception
 
     def receive_some(self, read_timeout):
@@ -54,12 +54,12 @@ class SyncSocket(object):
             try:
                 return self._sock.recv(BUFSIZE)
             except util.SSLWantReadError:
-                self._wait(readable=True, writable=False, read_timeout=read_timeout)
+                self._wait(readable=True, writable=False, timeout=read_timeout)
             except util.SSLWantWriteError:
-                self._wait(readable=False, writable=True, read_timeout=read_timeout)
+                self._wait(readable=False, writable=True, timeout=read_timeout)
             except (OSError, socket.error) as exc:
                 if exc.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
-                    self._wait(readable=True, writable=False, read_timeout=read_timeout)
+                    self._wait(readable=True, writable=False, timeout=read_timeout)
                 else:
                     raise
 

--- a/src/urllib3/_backends/sync_backend.py
+++ b/src/urllib3/_backends/sync_backend.py
@@ -49,17 +49,17 @@ class SyncSocket(object):
                 timeout=read_timeout):
             raise socket.timeout()  # XX use a backend-agnostic exception
 
-    def receive_some(self):
+    def receive_some(self, read_timeout):
         while True:
             try:
                 return self._sock.recv(BUFSIZE)
             except util.SSLWantReadError:
-                self._wait(readable=True, writable=False)
+                self._wait(readable=True, writable=False, read_timeout=read_timeout)
             except util.SSLWantWriteError:
-                self._wait(readable=False, writable=True)
+                self._wait(readable=False, writable=True, read_timeout=read_timeout)
             except (OSError, socket.error) as exc:
                 if exc.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
-                    self._wait(readable=True, writable=False)
+                    self._wait(readable=True, writable=False, read_timeout=read_timeout)
                 else:
                     raise
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -305,7 +305,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/upload', fields=fields)
         self.assertEqual(r.status, 200, r.data)
 
-    @pytest.mark.xfail
+    @pytest.mark.skip
     def test_nagle(self):
         """ Test that connections have TCP_NODELAY turned on """
         # This test needs to be here in order to be run. socket.create_connection actually tries

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -386,7 +386,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         finally:
             socket.setdefaulttimeout(default_timeout)
 
-    @pytest.mark.skip
     def test_delayed_body_read_timeout(self):
         timed_out = Event()
 
@@ -416,7 +415,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         finally:
             timed_out.set()
 
-    @pytest.mark.skip
     def test_delayed_body_read_timeout_with_preload(self):
         timed_out = Event()
 
@@ -546,7 +544,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
         self.assertIsInstance(cm.exception.reason, BadVersionError)
 
-    @pytest.mark.skip
+    @pytest.mark.xfail
     def test_connection_cleanup_on_read_timeout(self):
         timed_out = Event()
 
@@ -604,8 +602,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
             self.assertRaises(ProtocolError, response.read)
             self.assertEqual(poolsize, pool.pool.qsize())
 
-    # Tends to hang on PyPy 3 in Travis, and using pytest.timeout fails on Windows
-    @pytest.mark.skip
     def test_connection_closed_on_read_timeout_preload_false(self):
         timed_out = Event()
 
@@ -1101,7 +1097,6 @@ class TestSSL(SocketDummyServerTestCase):
             pool.request('GET', '/', retries=0)
         self.assertIsInstance(cm.exception.reason, SSLError)
 
-    @pytest.mark.skip
     def test_ssl_read_timeout(self):
         timed_out = Event()
 


### PR DESCRIPTION
In urllib3 master, the read timeouts are set on the underlying socket. Then makefile() is called, and this is how the read timeout work. In the bleach-spike branche, I think we need to store the read timeout explicitly in the connection, because reading the response is done by iterating over the connection object.