### PR TITLE
Try using unasync from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ matrix:
       env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
-    - python: 3.7-dev
-      env: TOXENV=py37
     - python: pypy2.7
       env: TOXENV=pypy
     - language: generic
@@ -74,7 +72,4 @@ matrix:
     - language: generic
       os: osx
       env: TOXENV=py34
-    - language: generic
-      os: osx
-      env: TOXENV=py37
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ matrix:
       env: TOXENV=py34
     - python: pypy2.7
       env: TOXENV=pypy
+    - python: pypy3.5
+      env: TOXENV=pypy3
     - language: generic
       os: osx
       env: TOXENV=py27

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst CHANGES.rst LICENSE.txt CONTRIBUTORS.txt dev-requirements.txt Makefile
+include README.rst CHANGES.rst LICENSE.txt CONTRIBUTORS.txt dev-requirements.txt Makefile pyproject.toml
 recursive-include dummyserver *
 recursive-include test *
 recursive-include docs *

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 mock==2.0.0
 coverage==4.5.1
-tox==2.9.1
 twine==1.11.0
 wheel==0.30.0
 tornado==5.0.2
@@ -9,6 +8,7 @@ pkginfo==1.4.2
 pytest-random-order==0.6.0
 pytest-timeout==1.3.1
 pytest==3.6.4
+tox==2.9.1
 h11==0.8.0
 cryptography==2.2.1
 trio==0.3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,4 +17,3 @@ twisted[tls]==17.9.0; os_name != 'nt'
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
 gcp-devrel-py-tools==0.0.15
-pip==18.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,4 @@ twisted[tls]==17.9.0; os_name != 'nt'
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
 gcp-devrel-py-tools==0.0.15
+pip==18.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "unasync"]
+requires = ["setuptools>=40.6.2", "wheel", "unasync"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "unasync"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "unasync"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from setuptools.command.build_py import build_py
 
 import os
 import re
-import tokenize as std_tokenize
-from tokenize import NAME, NEWLINE, NL, STRING, ENCODING
 import codecs
+
+import unasync  # requires pip>=10.0 for PEP 518 support
 
 
 base_path = os.path.dirname(__file__)
@@ -22,100 +21,6 @@ with codecs.open('README.rst', encoding='utf-8') as fp:
 with codecs.open('CHANGES.rst', encoding='utf-8') as fp:
     changes = fp.read()
 version = VERSION
-
-ASYNC_TO_SYNC = {
-    '__aenter__': '__enter__',
-    '__aexit__': '__exit__',
-    '__aiter__': '__iter__',
-    '__anext__': '__next__',
-    # TODO StopIteration is still accepted in Python 2, but the right change
-    # is 'raise StopAsyncIteration' -> 'return' since we want to use bleached
-    # code in Python 3.7+
-    'StopAsyncIteration': 'StopIteration',
-}
-
-
-def tokenize(f):
-    last_end = (1, 0)
-    for tok in std_tokenize.tokenize(f.readline):
-        if tok.type == ENCODING:
-            continue
-
-        if last_end[0] < tok.start[0]:
-            yield ('', STRING, ' \\\n')
-            last_end = (tok.start[0], 0)
-
-        space = ''
-        if tok.start > last_end:
-            assert tok.start[0] == last_end[0]
-            space = ' ' * (tok.start[1] - last_end[1])
-        yield (space, tok.type, tok.string)
-
-        last_end = tok.end
-        if tok.type in [NEWLINE, NL]:
-            last_end = (tok.end[0] + 1, 0)
-
-
-def bleach_tokens(tokens):
-    # TODO __await__, ...?
-    used_space = None
-    for space, toknum, tokval in tokens:
-        if tokval in ["async", "await"]:
-            # When removing async or await, we want to use the whitespace that
-            # was before async/await before the next token so that
-            # `print(await stuff)` becomes `print(stuff)` and not
-            # `print( stuff)`
-            used_space = space
-        else:
-            if toknum == NAME and tokval in ASYNC_TO_SYNC:
-                tokval = ASYNC_TO_SYNC[tokval]
-            if used_space is None:
-                used_space = space
-            yield (used_space, tokval)
-            used_space = None
-
-
-def untokenize(tokens):
-    return ''.join(space + tokval for space, tokval in tokens)
-
-
-def bleach(filepath, fromdir, todir):
-    with open(filepath, 'rb') as f:
-        encoding, _ = std_tokenize.detect_encoding(f.readline)
-        f.seek(0)
-        tokens = tokenize(f)
-        tokens = bleach_tokens(tokens)
-        result = untokenize(tokens)
-        outfilepath = filepath.replace(fromdir, todir)
-        os.makedirs(os.path.dirname(outfilepath), exist_ok=True)
-        with open(outfilepath, 'w', encoding=encoding) as f:
-            print(result, file=f, end='')
-
-
-class bleach_build_py(build_py):
-    """Monkeypatches build_py to add bleaching from _async to _sync"""
-    def run(self):
-        self._updated_files = []
-
-        # Base class code
-        if self.py_modules:
-            self.build_modules()
-        if self.packages:
-            self.build_packages()
-            self.build_package_data()
-
-        for f in self._updated_files:
-            if os.sep + '_async' + os.sep in f:
-                bleach(f, '_async', '_sync')
-
-        # Remaining base class code
-        self.byte_compile(self.get_outputs(include_bytecode=0))
-
-    def build_module(self, module, module_file, package):
-        outfile, copied = super().build_module(module, module_file, package)
-        if copied:
-            self._updated_files.append(outfile)
-        return outfile, copied
 
 
 setup(name='urllib3',
@@ -174,5 +79,5 @@ setup(name='urllib3',
               'PySocks>=1.5.6,<2.0,!=1.5.7',
           ]
       },
-      cmdclass={'build_py': bleach_build_py},
+      cmdclass={'build_py': unasync.build_py},
       )

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -7,7 +7,7 @@ import pytest
 
 try:
     from urllib3.contrib.securetransport import WrappedSocket
-except ImportError as e:
+except ImportError:
     pass
 
 pytestmark = pytest.mark.skip('SecureTransport currently not supported on v2!')

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,9 @@ setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
 
+[testenv:.package]
+deps=
+
 [testenv:gae]
 basepython = python2.7
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = flake8-py3, py27, py34, py35, py36, py37, pypy, pypy3
+# PEP 518 support
+isolated_build = True
 
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
Thanks to the work of @RatanShreshtha and I, unasync is now available on PyPI: https://pypi.org/project/unasync/. This project switches urllib3 to use it.

`pip install -e .` works! 🎉 But tox does not. 😿 I need to find out what's the problem, since tox says PEP 518 is supported, and I followed its docs.