### PR TITLE
Remove Python 2 only code from coverage reports

### DIFF
--- a/src/urllib3/util/wait.py
+++ b/src/urllib3/util/wait.py
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 5):
     # Modern Python, that retries syscalls by default
     def _retry_on_intr(fn, timeout):
         return fn(timeout)
-else:
+else:  # Python 2.7
     # Old and broken Pythons.
     def _retry_on_intr(fn, timeout):
         if timeout is None:


### PR DESCRIPTION
We don't know yet if we'll progress fast enough to support Python 2, so
let's worry about this later.