### PR TITLE
Fix test_connect_ipv6_addr.

### DIFF
--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -213,9 +213,12 @@ def _build_tunnel_request(host, port, headers):
 
     try:
         socket.inet_pton(socket.AF_INET6, host)
-        target = "[%s]:%d" % (host, port)
     except OSError:
+        # Not a raw IPv6 address
         target = "%s:%d" % (host, port)
+    else:
+        # raw IPv6 address
+        target = "[%s]:%d" % (host, port)
 
     if not isinstance(target, bytes):
         target = target.encode('latin1')

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -210,7 +210,13 @@ def _build_tunnel_request(host, port, headers):
     Builds a urllib3 Request object that is set up correctly to request a proxy
     to establish a TCP tunnel to the remote host.
     """
-    target = "%s:%d" % (host, port)
+
+    try:
+        socket.inet_pton(socket.AF_INET6, host)
+        target = "[%s]:%d" % (host, port)
+    except OSError:
+        target = "%s:%d" % (host, port)
+
     if not isinstance(target, bytes):
         target = target.encode('latin1')
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1022,7 +1022,6 @@ class TestProxyManager(SocketDummyServerTestCase):
         assert exception.response.status_code == 401
         assert exception.response.headers['x-custom-header'] == 'yougotit'
 
-    @pytest.mark.xfail
     def test_connect_ipv6_addr(self):
         ipv6_addr = '2001:4998:c:a06::2:4008'
 


### PR DESCRIPTION
I have added a check in for ipv6 host in `_build_tunnel_request` and accordingly modify the target, is there a better way ?