### PR TITLE
test_socketlevel: skip tests that are no longer flaky

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -346,7 +346,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         finally:
             timed_out.set()
 
-    @pytest.mark.skip  # flaky in CI
     def test_timeout_errors_cause_retries(self):
         def socket_handler(listener):
             sock_timeout = listener.accept()[0]
@@ -389,7 +388,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         finally:
             socket.setdefaulttimeout(default_timeout)
 
-    @pytest.mark.skip  # flaky in CI
     def test_delayed_body_read_timeout(self):
         timed_out = Event()
 
@@ -604,7 +602,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
             self.assertRaises(ProtocolError, response.read)
             self.assertEqual(poolsize, pool.pool.qsize())
 
-    @pytest.mark.skip  # flaky in CI
     def test_connection_closed_on_read_timeout_preload_false(self):
         timed_out = Event()
 
@@ -711,7 +708,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
         if not successful:
             self.fail("Timed out waiting for connection close")
 
-    @pytest.mark.skip  # Flaky in CI
     def test_release_conn_param_is_respected_after_timeout_retry(self):
         """For successful ```urlopen()```, the connection isn't released, even
         after a retry.
@@ -1098,7 +1094,6 @@ class TestSSL(SocketDummyServerTestCase):
             pool.request('GET', '/', retries=0)
         self.assertIsInstance(cm.exception.reason, SSLError)
 
-    @pytest.mark.skip  # flaky in CI
     def test_ssl_read_timeout(self):
         timed_out = Event()
 


### PR DESCRIPTION
Or at least they're less flaky than they used to be!