### PR TITLE
Merge from master (January 25th, 2019)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ dev (master)
 * Fixed issue where OpenSSL would block if an encrypted client private key was
   given and no password was given. Instead an ``SSLError`` is raised. (Pull #1489)
 
+* Require and validate certificates by default when using HTTPS (Pull #1507)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -202,11 +202,15 @@ recommended to set the ``Content-Type`` header::
 Certificate verification
 ------------------------
 
-It is highly recommended to always use SSL certificate verification.
-**By default, urllib3 does not verify HTTPS requests**.
+ .. note:: *New in version 1.25*
 
-In order to enable verification you will need a set of root certificates. The easiest
-and most reliable method is to use the `certifi <https://certifi.io/>`_ package which provides Mozilla's root certificate bundle::
+    HTTPS connections are now verified by default (``cert_reqs = 'CERT_REQUIRED'``).
+
+While you can disable certification verification, it is highly recommend to leave it on.
+
+Unless otherwise specified urllib3 will try to load the default system certificate stores.
+The most reliable cross-platform method is to use the `certifi <https://certifi.io/>`_
+package which provides Mozilla's root certificate bundle::
 
     pip install certifi
 

--- a/src/urllib3/_async/connection.py
+++ b/src/urllib3/_async/connection.py
@@ -366,7 +366,8 @@ class HTTP1Connection(object):
 
         # XX need to know whether this is the proxy or the final host that
         # we just did a handshake with!
-        check_host = assert_hostname or self._tunnel_host or self._host
+        # Google App Engine's httplib does not define _tunnel_host
+        check_host = assert_hostname or getattr(self, '_tunnel_host', None) or self._host
 
         # Stripping trailing dots from the hostname is important because
         # they indicate that this host is an absolute name (for DNS
@@ -478,7 +479,8 @@ class HTTP1Connection(object):
                 self, "Failed to establish a new connection: %s" % e)
 
         if ssl_context is not None:
-            if self._tunnel_host is not None:
+            # Google App Engine's httplib does not define _tunnel_host
+            if getattr(self, '_tunnel_host', None) is not None:
                 self._tunnel(self._sock)
 
             self._sock = await self._wrap_socket(

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -703,9 +703,6 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         if ssl is None:
             raise SSLError("SSL module is not available")
 
-        if ca_certs and cert_reqs is None:
-            cert_reqs = 'CERT_REQUIRED'
-
         self.ssl_context = _build_context(
             ssl_context, keyfile=key_file, certfile=cert_file,
             cert_reqs=cert_reqs, key_password=key_password, ca_certs=ca_certs,

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -62,7 +62,7 @@ _IP_ADDRESS_REGEX = re.compile(
 
 try:  # Test for SSL features
     import ssl
-    from ssl import wrap_socket, CERT_NONE, PROTOCOL_SSLv23
+    from ssl import wrap_socket, CERT_REQUIRED, PROTOCOL_SSLv23
     from ssl import HAS_SNI  # Has SNI?
     from ssl import SSLError as BaseSSLError
     from ssl import SSLWantReadError, SSLWantWriteError
@@ -208,7 +208,7 @@ def resolve_cert_reqs(candidate):
     constant which can directly be passed to wrap_socket.
     """
     if candidate is None:
-        return CERT_NONE
+        return CERT_REQUIRED
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -4,7 +4,7 @@ import socket
 from urllib3.contrib import socks
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 
-from dummyserver.server import DEFAULT_CERTS
+from dummyserver.server import DEFAULT_CERTS, DEFAULT_CA
 from dummyserver.testcase import IPV4SocketDummyServerTestCase
 
 import pytest
@@ -720,7 +720,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
-        pm = socks.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url, ca_certs=DEFAULT_CA)
         self.addCleanup(pm.clear)
         response = pm.request('GET', 'https://localhost')
 

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import ssl
 import pytest
 
 from urllib3.base import Response
@@ -25,7 +26,7 @@ from urllib3.exceptions import (
 
 from io import BytesIO
 from socket import error as SocketError
-from ssl import SSLError as BaseSSLError, CERT_REQUIRED
+from ssl import SSLError as BaseSSLError
 
 from dummyserver.server import DEFAULT_CA
 
@@ -344,7 +345,7 @@ class TestConnectionPool(object):
 
     def test_ca_certs_default_cert_required(self):
         with connection_from_url('https://google.com:80', ca_certs=DEFAULT_CA) as pool:
-            assert pool.ssl_context.verify_mode == CERT_REQUIRED
+            assert pool.ssl_context.verify_mode == ssl.CERT_REQUIRED
 
     def test_cleanup_on_extreme_connection_error(self):
         """

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -472,7 +472,7 @@ class TestUtil(object):
         assert timeout.get_connect_duration() == 37
 
     @pytest.mark.parametrize('candidate, requirements', [
-        (None, ssl.CERT_NONE),
+        (None, ssl.CERT_REQUIRED),
         (ssl.CERT_NONE, ssl.CERT_NONE),
         (ssl.CERT_REQUIRED, ssl.CERT_REQUIRED),
         ('REQUIRED', ssl.CERT_REQUIRED),

--- a/test/with_dummyserver/test_no_ssl.py
+++ b/test/with_dummyserver/test_no_ssl.py
@@ -29,7 +29,7 @@ class TestHTTPWithoutSSL(HTTPDummyServerTestCase, TestWithoutSSL):
 class TestHTTPSWithoutSSL(HTTPSDummyServerTestCase, TestWithoutSSL):
     def test_simple(self):
         try:
-            pool = urllib3.HTTPSConnectionPool(self.host, self.port)
+            pool = urllib3.HTTPSConnectionPool(self.host, self.port, cert_reqs="NONE")
         except urllib3.exceptions.SSLError as e:
             self.assertIn('SSL module is not available', str(e))
         finally:

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -27,7 +27,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.proxy_url = 'http://%s:%d' % (self.proxy_host, self.proxy_port)
 
     def test_basic_proxy(self):
-        http = proxy_from_url(self.proxy_url)
+        http = proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         r = http.request('GET', '%s/' % self.http_url)
@@ -65,7 +65,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.assertEqual(type(e.reason), ProxyError)
 
     def test_oldapi(self):
-        http = ProxyManager(connection_from_url(self.proxy_url))
+        http = ProxyManager(connection_from_url(self.proxy_url), ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         r = http.request('GET', '%s/' % self.http_url)
@@ -141,7 +141,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertNotEqual(r._pool.host, self.http_host_alt)
 
     def test_cross_protocol_redirect(self):
-        http = proxy_from_url(self.proxy_url)
+        http = proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         cross_protocol_location = '%s/echo?a=b' % self.https_url
@@ -161,7 +161,8 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_headers(self):
         http = proxy_from_url(self.proxy_url, headers={'Foo': 'bar'},
-                              proxy_headers={'Hickory': 'dickory'})
+                              proxy_headers={'Hickory': 'dickory'},
+                              ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url)
@@ -184,13 +185,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertIsNone(returned_headers.get('Hickory'))
         self.assertEqual(returned_headers.get('Host'),
                          '%s:%s' % (self.https_host, self.https_port))
-
-        r = http.request_encode_url('GET', '%s/headers' % self.https_url_alt)
-        returned_headers = json.loads(r.data.decode())
-        self.assertEqual(returned_headers.get('Foo'), 'bar')
-        self.assertIsNone(returned_headers.get('Hickory'))
-        self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s' % (self.https_host_alt, self.https_port))
 
         r = http.request_encode_body('POST', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
@@ -249,7 +243,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
 
     def test_proxy_pooling(self):
-        http = proxy_from_url(self.proxy_url)
+        http = proxy_from_url(self.proxy_url, cert_reqs='NONE')
         self.addCleanup(http.clear)
 
         for x in range(2):
@@ -315,7 +309,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_scheme_host_case_insensitive(self):
         """Assert that upper-case schemes and hosts are normalized."""
-        http = proxy_from_url(self.proxy_url.upper())
+        http = proxy_from_url(self.proxy_url.upper(), ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         r = http.request('GET', '%s/' % self.http_url.upper())
@@ -337,7 +331,7 @@ class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
         self.proxy_url = 'http://[%s]:%d' % (self.proxy_host, self.proxy_port)
 
     def test_basic_ipv6_proxy(self):
-        http = proxy_from_url(self.proxy_url)
+        http = proxy_from_url(self.proxy_url, ca_certs=DEFAULT_CA)
         self.addCleanup(http.clear)
 
         r = http.request('GET', '%s/' % self.http_url)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1048,7 +1048,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         self._start_server(echo_socket_handler)
         base_url = 'http://%s:%d' % (self.host, self.port)
 
-        proxy = proxy_from_url(base_url)
+        proxy = proxy_from_url(base_url, ca_certs=DEFAULT_CA)
         self.addCleanup(proxy.clear)
 
         url = 'https://{0}'.format(self.host)
@@ -1124,7 +1124,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         self._start_server(echo_socket_handler)
         base_url = 'http://%s:%d' % (self.host, self.port)
 
-        proxy = proxy_from_url(base_url)
+        proxy = proxy_from_url(base_url, cert_reqs='NONE')
         self.addCleanup(proxy.clear)
 
         url = 'https://[{0}]'.format(ipv6_addr)
@@ -1178,8 +1178,7 @@ class TestSSL(SocketDummyServerTestCase):
             ssl_sock = ssl.wrap_socket(sock,
                                        server_side=True,
                                        keyfile=DEFAULT_CERTS['keyfile'],
-                                       certfile=DEFAULT_CERTS['certfile'],
-                                       ca_certs=DEFAULT_CA)
+                                       certfile=DEFAULT_CERTS['certfile'])
 
             buf = b''
             while not buf.endswith(b'\r\n\r\n'):
@@ -1198,7 +1197,7 @@ class TestSSL(SocketDummyServerTestCase):
             ssl_sock.close()
 
         self._start_server(socket_handler)
-        pool = HTTPSConnectionPool(self.host, self.port)
+        pool = HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA)
         self.addCleanup(pool.close)
 
         response = pool.urlopen('GET', '/', retries=0, preload_content=False,
@@ -1289,7 +1288,7 @@ class TestSSL(SocketDummyServerTestCase):
 
         self._start_server(socket_handler)
 
-        pool = HTTPSConnectionPool(self.host, self.port)
+        pool = HTTPSConnectionPool(self.host, self.port, ca_certs=DEFAULT_CA)
         self.addCleanup(pool.close)
         response = pool.urlopen('GET', '/', retries=1)
         self.assertEqual(response.data, b'Success')


### PR DESCRIPTION
This includes a Google App Engine tweak and a change to check SSL certificates by default. My understanding is that this was already the default since Cory Benfield's v2 branch, but this commit is more comprehensive, eg. it switches more tests to verified requests. I also tested locally that verification happens when just using urllib3 as a user.

And there are still flaky tests, but the US is sleeping, so the CI should be fast enough to avoid the flakiness.