### PR TITLE
Merge from master (April 24th, 2019, before Nox)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 stage: test
+dist: xenial
 
 before_install:
   - env
@@ -46,6 +47,8 @@ matrix:
       env: TOXENV=py27
     - python: 2.7
       env: TOXENV=py27-nobrotli
+    - python: 2.7
+      env: TOXENV=py27-google-brotli
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
@@ -54,23 +57,15 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-nobrotli
-      dist: xenial
-      sudo: required
+    - python: 3.7
+      env: TOXENV=py37-google-brotli
     - python: 3.8-dev
       env: TOXENV=py38
-      dist: xenial
-      sudo: required
     - python: pypy2.7-7.1.1
-      dist: xenial
-      sudo: required
       env: TOXENV=pypy
     - python: pypy3.6-7.1.1
-      dist: xenial
-      sudo: required
       env: TOXENV=pypy3
     - language: generic
       os: osx
@@ -94,8 +89,6 @@ matrix:
 
     # - python: 3.7
     #   env: DOWNSTREAM=requests
-    #   dist: xenial
-    #   sudo: required
     #   stage: integration
 
     # - python: 2.7
@@ -104,9 +97,12 @@ matrix:
 
     # - python: 3.7
     #   env: DOWNSTREAM=botocore
-    #   dist: xenial
-    #   sudo: required
     #   stage: integration
+
+    - python: 3.7
+      stage: deploy
+      script:
+        - ./_travis/deploy.sh
 
   allow_failures:
     - python: 3.6
@@ -125,34 +121,13 @@ matrix:
       env: TOXENV=py35
 
 stages:
-  - test
+  - name: test
+    if: tag IS blank
 
   # Run integration tests for release candidates
   - name: integration
-    if: type = pull_request AND head_branch =~ ^release-[\d.]+$
+    if: type = pull_request AND head_branch =~ ^release-[\d.]+$ AND tag IS blank
 
-deploy:
-  - provider: script
-    script: bash _travis/deploy.sh
-    skip_cleanup: true
-    on:
-      branch: master
-      repo: urllib3/urllib3
-      tags: true
-      python: 3.7
-
-  - provider: releases
-    api_key:
-      secure: ...  # GitHub access token
-    name: "$TRAVIS_TAG"
-    body: "Release $TRAVIS_TAG"
-    draft: true
-    skip_cleanup: true
-    file_glob: true
-    file: dist/*
-    overwrite: true
-    on:
-      branch: master
-      repo: urllib3/urllib3
-      tags: true
-      python: 3.7
+  # Deploy on any tags
+  - name: deploy
+    if: branch = master AND tag IS present

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,31 +30,37 @@ Upcoming 2.0 Changes
 dev (master)
 ------------
 
-* Implemented a more efficient ``HTTPResponse.__iter__()`` method. (Issue #1483)
+* Add support for Google's ``Brotli`` package. (Pull #1572, Pull #1579)
+
+* ... [Short description of non-trivial change.] (Issue #)
+
+
+1.25 (2019-04-22)
+-----------------
+
+* Require and validate certificates by default when using HTTPS (Pull #1507)
 
 * Upgraded ``urllib3.utils.parse_url()`` to be RFC 3986 compliant. (Pull #1487)
 
 * Added support for ``key_password`` for ``HTTPSConnectionPool`` to use
   encrypted ``key_file`` without creating your own ``SSLContext`` object. (Pull #1489)
 
+* Add TLSv1.3 support to CPython, pyOpenSSL, and SecureTransport ``SSLContext``
+  implementations. (Pull #1496)
+
+* Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft. (Issue #303, PR #1492)
+
 * Fixed issue where OpenSSL would block if an encrypted client private key was
   given and no password was given. Instead an ``SSLError`` is raised. (Pull #1489)
-
-* Require and validate certificates by default when using HTTPS (Pull #1507)
 
 * Added support for Brotli content encoding. It is enabled automatically if
   ``brotlipy`` package is installed which can be requested with
   ``urllib3[brotli]`` extra. (Pull #1532)
 
-* Add TLSv1.3 support to CPython, pyOpenSSL, and SecureTransport ``SSLContext``
-  implementations. (Pull #1496)
-
 * Drop ciphers using DSS key exchange from default TLS cipher suites.
   Improve default ciphers when using SecureTransport. (Pull #1496)
 
-* Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft. (Issue #303, PR #1492)
-
-* ... [Short description of non-trivial change.] (Issue #)
+* Implemented a more efficient ``HTTPResponse.__iter__()`` method. (Issue #1483)
 
 
 1.24.2 (2019-04-17)

--- a/_travis/downstream/requests-requirements.txt
+++ b/_travis/downstream/requests-requirements.txt
@@ -1,0 +1,9 @@
+pytest-mock
+pysocks
+httpbin
+
+# kennethreitz/requests#5049
+pytest<4.1
+
+# kennethreitz/requests#5004
+pytest-httpbin==0.3.0

--- a/_travis/downstream/requests.sh
+++ b/_travis/downstream/requests.sh
@@ -7,15 +7,12 @@ case "${1}" in
         git clone --depth 1 https://github.com/kennethreitz/requests
         cd requests
         git rev-parse HEAD
-        python -m pip install --upgrade pipenv
-        pipenv install --dev --skip-lock
-        
-        # See: kennethreitz/requests/5004
-        python -m pip install pytest-httpbin==0.3.0
+        python -m pip install -r ${TRAVIS_BUILD_DIR}/_travis/downstream/requests-requirements.txt
+        python -m pip install .
         ;;
     run)
         cd requests
-        pipenv run py.test -n 8 --boxed
+        pytest tests/
         ;;
     *)
         exit 1

--- a/_travis/upload_coverage.sh
+++ b/_travis/upload_coverage.sh
@@ -2,6 +2,8 @@
 
 set -exo pipefail
 
-source .tox/${TOXENV}/bin/activate
-pip install codecov
-codecov --env TRAVIS_OS_NAME,TOXENV
+if [[ -e .coverage ]]; then
+    source .tox/${TOXENV}/bin/activate
+    pip install codecov
+    codecov --env TRAVIS_OS_NAME,TOXENV
+fi

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -96,14 +96,21 @@ class GzipDecoder(object):
 
 if brotli is not None:
     class BrotliDecoder(object):
+        # Supports both 'brotlipy' and 'Brotli' packages
+        # since they share an import name. The top branches
+        # are for 'brotlipy' and bottom branches for 'Brotli'
         def __init__(self):
             self._obj = brotli.Decompressor()
 
-        def __getattr__(self, name):
-            return getattr(self._obj, name)
-
         def decompress(self, data):
-            return self._obj.decompress(data)
+            if hasattr(self._obj, 'decompress'):
+                return self._obj.decompress(data)
+            return self._obj.process(data)
+
+        def flush(self):
+            if hasattr(self._obj, 'flush'):
+                return self._obj.flush()
+            return b''
 
 
 class MultiDecoder(object):
@@ -266,7 +273,7 @@ class HTTPResponse(io.IOBase):
                     self._decoder = _get_decoder(content_encoding)
     DECODER_ERROR_CLASSES = (IOError, zlib.error)
     if brotli is not None:
-        DECODER_ERROR_CLASSES += (brotli.Error,)
+        DECODER_ERROR_CLASSES += (brotli.error,)
 
     def _decode(self, data, decode_content, flush_decoder):
         """

--- a/src/urllib3/packages/rfc3986/__init__.py
+++ b/src/urllib3/packages/rfc3986/__init__.py
@@ -22,6 +22,8 @@ See http://rfc3986.readthedocs.io/ for detailed documentation.
 :license: Apache v2.0, see LICENSE for details
 """
 
+from .api import iri_reference
+from .api import IRIReference
 from .api import is_valid_uri
 from .api import normalize_uri
 from .api import uri_reference
@@ -34,14 +36,16 @@ __author__ = 'Ian Stapleton Cordasco'
 __author_email__ = 'graffatcolmingov@gmail.com'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Rackspace'
-__version__ = '1.2.0'
+__version__ = '1.3.1'
 
 __all__ = (
     'ParseResult',
     'URIReference',
+    'IRIReference',
     'is_valid_uri',
     'normalize_uri',
     'uri_reference',
+    'iri_reference',
     'urlparse',
     '__title__',
     '__author__',

--- a/src/urllib3/packages/rfc3986/_mixin.py
+++ b/src/urllib3/packages/rfc3986/_mixin.py
@@ -1,0 +1,353 @@
+"""Module containing the implementation of the URIMixin class."""
+import warnings
+
+from . import exceptions as exc
+from . import misc
+from . import normalizers
+from . import validators
+
+
+class URIMixin(object):
+    """Mixin with all shared methods for URIs and IRIs."""
+
+    __hash__ = tuple.__hash__
+
+    def authority_info(self):
+        """Return a dictionary with the ``userinfo``, ``host``, and ``port``.
+
+        If the authority is not valid, it will raise a
+        :class:`~rfc3986.exceptions.InvalidAuthority` Exception.
+
+        :returns:
+            ``{'userinfo': 'username:password', 'host': 'www.example.com',
+            'port': '80'}``
+        :rtype: dict
+        :raises rfc3986.exceptions.InvalidAuthority:
+            If the authority is not ``None`` and can not be parsed.
+        """
+        if not self.authority:
+            return {'userinfo': None, 'host': None, 'port': None}
+
+        match = self._match_subauthority()
+
+        if match is None:
+            # In this case, we have an authority that was parsed from the URI
+            # Reference, but it cannot be further parsed by our
+            # misc.SUBAUTHORITY_MATCHER. In this case it must not be a valid
+            # authority.
+            raise exc.InvalidAuthority(self.authority.encode(self.encoding))
+
+        # We had a match, now let's ensure that it is actually a valid host
+        # address if it is IPv4
+        matches = match.groupdict()
+        host = matches.get('host')
+
+        if (host and misc.IPv4_MATCHER.match(host) and not
+                validators.valid_ipv4_host_address(host)):
+            # If we have a host, it appears to be IPv4 and it does not have
+            # valid bytes, it is an InvalidAuthority.
+            raise exc.InvalidAuthority(self.authority.encode(self.encoding))
+
+        return matches
+
+    def _match_subauthority(self):
+        return misc.SUBAUTHORITY_MATCHER.match(self.authority)
+
+    @property
+    def host(self):
+        """If present, a string representing the host."""
+        try:
+            authority = self.authority_info()
+        except exc.InvalidAuthority:
+            return None
+        return authority['host']
+
+    @property
+    def port(self):
+        """If present, the port extracted from the authority."""
+        try:
+            authority = self.authority_info()
+        except exc.InvalidAuthority:
+            return None
+        return authority['port']
+
+    @property
+    def userinfo(self):
+        """If present, the userinfo extracted from the authority."""
+        try:
+            authority = self.authority_info()
+        except exc.InvalidAuthority:
+            return None
+        return authority['userinfo']
+
+    def is_absolute(self):
+        """Determine if this URI Reference is an absolute URI.
+
+        See http://tools.ietf.org/html/rfc3986#section-4.3 for explanation.
+
+        :returns: ``True`` if it is an absolute URI, ``False`` otherwise.
+        :rtype: bool
+        """
+        return bool(misc.ABSOLUTE_URI_MATCHER.match(self.unsplit()))
+
+    def is_valid(self, **kwargs):
+        """Determine if the URI is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the :class:`~rfc3986.validators.Validator` object instead.
+
+        :param bool require_scheme: Set to ``True`` if you wish to require the
+            presence of the scheme component.
+        :param bool require_authority: Set to ``True`` if you wish to require
+            the presence of the authority component.
+        :param bool require_path: Set to ``True`` if you wish to require the
+            presence of the path component.
+        :param bool require_query: Set to ``True`` if you wish to require the
+            presence of the query component.
+        :param bool require_fragment: Set to ``True`` if you wish to require
+            the presence of the fragment component.
+        :returns: ``True`` if the URI is valid. ``False`` otherwise.
+        :rtype: bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        validators = [
+            (self.scheme_is_valid, kwargs.get('require_scheme', False)),
+            (self.authority_is_valid, kwargs.get('require_authority', False)),
+            (self.path_is_valid, kwargs.get('require_path', False)),
+            (self.query_is_valid, kwargs.get('require_query', False)),
+            (self.fragment_is_valid, kwargs.get('require_fragment', False)),
+            ]
+        return all(v(r) for v, r in validators)
+
+    def authority_is_valid(self, require=False):
+        """Determine if the authority component is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the :class:`~rfc3986.validators.Validator` object instead.
+
+        :param bool require:
+            Set to ``True`` to require the presence of this component.
+        :returns:
+            ``True`` if the authority is valid. ``False`` otherwise.
+        :rtype:
+            bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        try:
+            self.authority_info()
+        except exc.InvalidAuthority:
+            return False
+
+        return validators.authority_is_valid(
+            self.authority,
+            host=self.host,
+            require=require,
+        )
+
+    def scheme_is_valid(self, require=False):
+        """Determine if the scheme component is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the :class:`~rfc3986.validators.Validator` object instead.
+
+        :param str require: Set to ``True`` to require the presence of this
+            component.
+        :returns: ``True`` if the scheme is valid. ``False`` otherwise.
+        :rtype: bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        return validators.scheme_is_valid(self.scheme, require)
+
+    def path_is_valid(self, require=False):
+        """Determine if the path component is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the :class:`~rfc3986.validators.Validator` object instead.
+
+        :param str require: Set to ``True`` to require the presence of this
+            component.
+        :returns: ``True`` if the path is valid. ``False`` otherwise.
+        :rtype: bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        return validators.path_is_valid(self.path, require)
+
+    def query_is_valid(self, require=False):
+        """Determine if the query component is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the :class:`~rfc3986.validators.Validator` object instead.
+
+        :param str require: Set to ``True`` to require the presence of this
+            component.
+        :returns: ``True`` if the query is valid. ``False`` otherwise.
+        :rtype: bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        return validators.query_is_valid(self.query, require)
+
+    def fragment_is_valid(self, require=False):
+        """Determine if the fragment component is valid.
+
+        .. deprecated:: 1.1.0
+
+            Use the Validator object instead.
+
+        :param str require: Set to ``True`` to require the presence of this
+            component.
+        :returns: ``True`` if the fragment is valid. ``False`` otherwise.
+        :rtype: bool
+        """
+        warnings.warn("Please use rfc3986.validators.Validator instead. "
+                      "This method will be eventually removed.",
+                      DeprecationWarning)
+        return validators.fragment_is_valid(self.fragment, require)
+
+    def normalized_equality(self, other_ref):
+        """Compare this URIReference to another URIReference.
+
+        :param URIReference other_ref: (required), The reference with which
+            we're comparing.
+        :returns: ``True`` if the references are equal, ``False`` otherwise.
+        :rtype: bool
+        """
+        return tuple(self.normalize()) == tuple(other_ref.normalize())
+
+    def resolve_with(self, base_uri, strict=False):
+        """Use an absolute URI Reference to resolve this relative reference.
+
+        Assuming this is a relative reference that you would like to resolve,
+        use the provided base URI to resolve it.
+
+        See http://tools.ietf.org/html/rfc3986#section-5 for more information.
+
+        :param base_uri: Either a string or URIReference. It must be an
+            absolute URI or it will raise an exception.
+        :returns: A new URIReference which is the result of resolving this
+            reference using ``base_uri``.
+        :rtype: :class:`URIReference`
+        :raises rfc3986.exceptions.ResolutionError:
+            If the ``base_uri`` is not an absolute URI.
+        """
+        if not isinstance(base_uri, URIMixin):
+            base_uri = type(self).from_string(base_uri)
+
+        if not base_uri.is_absolute():
+            raise exc.ResolutionError(base_uri)
+
+        # This is optional per
+        # http://tools.ietf.org/html/rfc3986#section-5.2.1
+        base_uri = base_uri.normalize()
+
+        # The reference we're resolving
+        resolving = self
+
+        if not strict and resolving.scheme == base_uri.scheme:
+            resolving = resolving.copy_with(scheme=None)
+
+        # http://tools.ietf.org/html/rfc3986#page-32
+        if resolving.scheme is not None:
+            target = resolving.copy_with(
+                path=normalizers.normalize_path(resolving.path)
+            )
+        else:
+            if resolving.authority is not None:
+                target = resolving.copy_with(
+                    scheme=base_uri.scheme,
+                    path=normalizers.normalize_path(resolving.path)
+                )
+            else:
+                if resolving.path is None:
+                    if resolving.query is not None:
+                        query = resolving.query
+                    else:
+                        query = base_uri.query
+                    target = resolving.copy_with(
+                        scheme=base_uri.scheme,
+                        authority=base_uri.authority,
+                        path=base_uri.path,
+                        query=query
+                    )
+                else:
+                    if resolving.path.startswith('/'):
+                        path = normalizers.normalize_path(resolving.path)
+                    else:
+                        path = normalizers.normalize_path(
+                            misc.merge_paths(base_uri, resolving.path)
+                        )
+                    target = resolving.copy_with(
+                        scheme=base_uri.scheme,
+                        authority=base_uri.authority,
+                        path=path,
+                        query=resolving.query
+                    )
+        return target
+
+    def unsplit(self):
+        """Create a URI string from the components.
+
+        :returns: The URI Reference reconstituted as a string.
+        :rtype: str
+        """
+        # See http://tools.ietf.org/html/rfc3986#section-5.3
+        result_list = []
+        if self.scheme:
+            result_list.extend([self.scheme, ':'])
+        if self.authority:
+            result_list.extend(['//', self.authority])
+        if self.path:
+            result_list.append(self.path)
+        if self.query is not None:
+            result_list.extend(['?', self.query])
+        if self.fragment is not None:
+            result_list.extend(['#', self.fragment])
+        return ''.join(result_list)
+
+    def copy_with(self, scheme=misc.UseExisting, authority=misc.UseExisting,
+                  path=misc.UseExisting, query=misc.UseExisting,
+                  fragment=misc.UseExisting):
+        """Create a copy of this reference with the new components.
+
+        :param str scheme:
+            (optional) The scheme to use for the new reference.
+        :param str authority:
+            (optional) The authority to use for the new reference.
+        :param str path:
+            (optional) The path to use for the new reference.
+        :param str query:
+            (optional) The query to use for the new reference.
+        :param str fragment:
+            (optional) The fragment to use for the new reference.
+        :returns:
+            New URIReference with provided components.
+        :rtype:
+            URIReference
+        """
+        attributes = {
+            'scheme': scheme,
+            'authority': authority,
+            'path': path,
+            'query': query,
+            'fragment': fragment,
+        }
+        for key, value in list(attributes.items()):
+            if value is misc.UseExisting:
+                del attributes[key]
+        uri = self._replace(**attributes)
+        uri.encoding = self.encoding
+        return uri

--- a/src/urllib3/packages/rfc3986/api.py
+++ b/src/urllib3/packages/rfc3986/api.py
@@ -19,6 +19,7 @@ This module defines functions and provides access to the public attributes
 and classes of rfc3986.
 """
 
+from .iri import IRIReference
 from .parseresult import ParseResult
 from .uri import URIReference
 
@@ -35,6 +36,20 @@ def uri_reference(uri, encoding='utf-8'):
     :rtype: :class:`URIReference`
     """
     return URIReference.from_string(uri, encoding)
+
+
+def iri_reference(iri, encoding='utf-8'):
+    """Parse a IRI string into an IRIReference.
+
+    This is a convenience function. You could achieve the same end by using
+    ``IRIReference.from_string(iri)``.
+
+    :param str iri: The IRI which needs to be parsed into a reference.
+    :param str encoding: The encoding of the string provided
+    :returns: A parsed IRI
+    :rtype: :class:`IRIReference`
+    """
+    return IRIReference.from_string(iri, encoding)
 
 
 def is_valid_uri(uri, encoding='utf-8', **kwargs):

--- a/src/urllib3/packages/rfc3986/exceptions.py
+++ b/src/urllib3/packages/rfc3986/exceptions.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Exceptions module for rfc3986."""
 
+from . import compat
+
 
 class RFC3986Exception(Exception):
     """Base class for all rfc3986 exception classes."""
@@ -14,7 +16,8 @@ class InvalidAuthority(RFC3986Exception):
     def __init__(self, authority):
         """Initialize the exception with the invalid authority."""
         super(InvalidAuthority, self).__init__(
-            "The authority ({0}) is not valid.".format(authority))
+            u"The authority ({0}) is not valid.".format(
+                compat.to_str(authority)))
 
 
 class InvalidPort(RFC3986Exception):
@@ -109,3 +112,7 @@ class InvalidComponentsError(ValidationError):
             uri,
             self.components,
         )
+
+
+class MissingDependencyError(RFC3986Exception):
+    """Exception raised when an IRI is encoded without the 'idna' module."""

--- a/src/urllib3/packages/rfc3986/iri.py
+++ b/src/urllib3/packages/rfc3986/iri.py
@@ -1,0 +1,147 @@
+"""Module containing the implementation of the IRIReference class."""
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014 Rackspace
+# Copyright (c) 2015 Ian Stapleton Cordasco
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import namedtuple
+
+from . import compat
+from . import exceptions
+from . import misc
+from . import normalizers
+from . import uri
+
+
+try:
+    import idna
+except ImportError:  # pragma: no cover
+    idna = None
+
+
+class IRIReference(namedtuple('IRIReference', misc.URI_COMPONENTS),
+                   uri.URIMixin):
+    """Immutable object representing a parsed IRI Reference.
+
+    Can be encoded into an URIReference object via the procedure
+    specified in RFC 3987 Section 3.1
+
+     .. note::
+        The IRI submodule is a new interface and may possibly change in
+        the future. Check for changes to the interface when upgrading.
+    """
+
+    slots = ()
+
+    def __new__(cls, scheme, authority, path, query, fragment,
+                encoding='utf-8'):
+        """Create a new IRIReference."""
+        ref = super(IRIReference, cls).__new__(
+            cls,
+            scheme or None,
+            authority or None,
+            path or None,
+            query,
+            fragment)
+        ref.encoding = encoding
+        return ref
+
+    def __eq__(self, other):
+        """Compare this reference to another."""
+        other_ref = other
+        if isinstance(other, tuple):
+            other_ref = self.__class__(*other)
+        elif not isinstance(other, IRIReference):
+            try:
+                other_ref = self.__class__.from_string(other)
+            except TypeError:
+                raise TypeError(
+                    'Unable to compare {0}() to {1}()'.format(
+                        type(self).__name__, type(other).__name__))
+
+        # See http://tools.ietf.org/html/rfc3986#section-6.2
+        return tuple(self) == tuple(other_ref)
+
+    def _match_subauthority(self):
+        return misc.ISUBAUTHORITY_MATCHER.match(self.authority)
+
+    @classmethod
+    def from_string(cls, iri_string, encoding='utf-8'):
+        """Parse a IRI reference from the given unicode IRI string.
+
+        :param str iri_string: Unicode IRI to be parsed into a reference.
+        :param str encoding: The encoding of the string provided
+        :returns: :class:`IRIReference` or subclass thereof
+        """
+        iri_string = compat.to_str(iri_string, encoding)
+
+        split_iri = misc.IRI_MATCHER.match(iri_string).groupdict()
+        return cls(
+            split_iri['scheme'], split_iri['authority'],
+            normalizers.encode_component(split_iri['path'], encoding),
+            normalizers.encode_component(split_iri['query'], encoding),
+            normalizers.encode_component(split_iri['fragment'], encoding),
+            encoding,
+        )
+
+    def encode(self, idna_encoder=None):  # noqa: C901
+        """Encode an IRIReference into a URIReference instance.
+
+        If the ``idna`` module is installed or the ``rfc3986[idna]``
+        extra is used then unicode characters in the IRI host
+        component will be encoded with IDNA2008.
+
+        :param idna_encoder:
+            Function that encodes each part of the host component
+            If not given will raise an exception if the IRI
+            contains a host component.
+        :rtype: uri.URIReference
+        :returns: A URI reference
+        """
+        authority = self.authority
+        if authority:
+            if idna_encoder is None:
+                if idna is None:  # pragma: no cover
+                    raise exceptions.MissingDependencyError(
+                        "Could not import the 'idna' module "
+                        "and the IRI hostname requires encoding"
+                    )
+
+                def idna_encoder(name):
+                    if any(ord(c) > 128 for c in name):
+                        try:
+                            return idna.encode(name.lower(),
+                                               strict=True,
+                                               std3_rules=True)
+                        except idna.IDNAError:
+                            raise exceptions.InvalidAuthority(self.authority)
+                    return name
+
+            authority = ""
+            if self.host:
+                authority = ".".join([compat.to_str(idna_encoder(part))
+                                      for part in self.host.split(".")])
+
+            if self.userinfo is not None:
+                authority = (normalizers.encode_component(
+                             self.userinfo, self.encoding) + '@' + authority)
+
+            if self.port is not None:
+                authority += ":" + str(self.port)
+
+        return uri.URIReference(self.scheme,
+                                authority,
+                                path=self.path,
+                                query=self.query,
+                                fragment=self.fragment,
+                                encoding=self.encoding)

--- a/src/urllib3/packages/rfc3986/misc.py
+++ b/src/urllib3/packages/rfc3986/misc.py
@@ -58,7 +58,14 @@ SUBAUTHORITY_MATCHER = re.compile((
              abnf_regexp.PORT_RE))
 
 
+HOST_MATCHER = re.compile('^' + abnf_regexp.HOST_RE + '$')
 IPv4_MATCHER = re.compile('^' + abnf_regexp.IPv4_RE + '$')
+IPv6_MATCHER = re.compile(r'^\[' + abnf_regexp.IPv6_ADDRZ_RFC4007_RE + r'\]$')
+
+# Used by host validator
+IPv6_NO_RFC4007_MATCHER = re.compile(r'^\[%s\]$' % (
+    abnf_regexp.IPv6_ADDRZ_RE
+))
 
 # Matcher used to validate path components
 PATH_MATCHER = re.compile(abnf_regexp.PATH_RE)
@@ -76,7 +83,8 @@ FRAGMENT_MATCHER = QUERY_MATCHER
 SCHEME_MATCHER = re.compile('^{0}$'.format(abnf_regexp.SCHEME_RE))
 
 RELATIVE_REF_MATCHER = re.compile(r'^%s(\?%s)?(#%s)?$' % (
-    abnf_regexp.RELATIVE_PART_RE, abnf_regexp.QUERY_RE,
+    abnf_regexp.RELATIVE_PART_RE,
+    abnf_regexp.QUERY_RE,
     abnf_regexp.FRAGMENT_RE,
 ))
 
@@ -86,6 +94,42 @@ ABSOLUTE_URI_MATCHER = re.compile(r'^%s:%s(\?%s)?$' % (
     abnf_regexp.HIER_PART_RE,
     abnf_regexp.QUERY_RE[1:-1],
 ))
+
+# ###############
+# IRIs / RFC 3987
+# ###############
+
+IRI_MATCHER = re.compile(abnf_regexp.URL_PARSING_RE, re.UNICODE)
+
+ISUBAUTHORITY_MATCHER = re.compile((
+    u'^(?:(?P<userinfo>{0})@)?'  # iuserinfo
+    u'(?P<host>{1})'  # ihost
+    u':?(?P<port>{2})?$'  # port
+    ).format(abnf_regexp.IUSERINFO_RE,
+             abnf_regexp.IHOST_RE,
+             abnf_regexp.PORT_RE), re.UNICODE)
+
+
+IHOST_MATCHER = re.compile('^' + abnf_regexp.IHOST_RE + '$', re.UNICODE)
+
+IPATH_MATCHER = re.compile(abnf_regexp.IPATH_RE, re.UNICODE)
+
+IQUERY_MATCHER = re.compile(abnf_regexp.IQUERY_RE, re.UNICODE)
+
+IFRAGMENT_MATCHER = re.compile(abnf_regexp.IFRAGMENT_RE, re.UNICODE)
+
+
+RELATIVE_IRI_MATCHER = re.compile(u'^%s(?:\\?%s)?(?:%s)?$' % (
+    abnf_regexp.IRELATIVE_PART_RE,
+    abnf_regexp.IQUERY_RE,
+    abnf_regexp.IFRAGMENT_RE
+), re.UNICODE)
+
+ABSOLUTE_IRI_MATCHER = re.compile(u'^%s:%s(?:\\?%s)?$' % (
+    abnf_regexp.COMPONENT_PATTERN_DICT['scheme'],
+    abnf_regexp.IHIER_PART_RE,
+    abnf_regexp.IQUERY_RE[1:-1]
+), re.UNICODE)
 
 
 # Path merger as defined in http://tools.ietf.org/html/rfc3986#section-5.2.3

--- a/src/urllib3/packages/rfc3986/normalizers.py
+++ b/src/urllib3/packages/rfc3986/normalizers.py
@@ -49,6 +49,21 @@ def normalize_password(password):
 
 def normalize_host(host):
     """Normalize a host string."""
+    if misc.IPv6_MATCHER.match(host):
+        percent = host.find('%')
+        if percent != -1:
+            percent_25 = host.find('%25')
+
+            # Replace RFC 4007 IPv6 Zone ID delimiter '%' with '%25'
+            # from RFC 6874. If the host is '[<IPv6 addr>%25]' then we
+            # assume RFC 4007 and normalize to '[<IPV6 addr>%2525]'
+            if percent_25 == -1 or percent < percent_25 or \
+                    (percent == percent_25 and percent_25 == len(host) - 4):
+                host = host.replace('%', '%25', 1)
+
+            # Don't normalize the casing of the Zone ID
+            return host[:percent].lower() + host[percent:]
+
     return host.lower()
 
 
@@ -147,6 +162,6 @@ def encode_component(uri_component, encoding):
                 or (byte_ord < 128 and byte.decode() in misc.NON_PCT_ENCODED)):
             encoded_uri.extend(byte)
             continue
-        encoded_uri.extend('%{0:02x}'.format(byte_ord).encode())
+        encoded_uri.extend('%{0:02x}'.format(byte_ord).encode().upper())
 
     return encoded_uri.decode(encoding)

--- a/src/urllib3/packages/rfc3986/uri.py
+++ b/src/urllib3/packages/rfc3986/uri.py
@@ -15,16 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import namedtuple
-import warnings
 
 from . import compat
-from . import exceptions as exc
 from . import misc
 from . import normalizers
-from . import validators
+from ._mixin import URIMixin
 
 
-class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
+class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS), URIMixin):
     """Immutable object representing a parsed URI Reference.
 
     .. note::
@@ -116,228 +114,6 @@ class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
         naive_equality = tuple(self) == tuple(other_ref)
         return naive_equality or self.normalized_equality(other_ref)
 
-    @classmethod
-    def from_string(cls, uri_string, encoding='utf-8'):
-        """Parse a URI reference from the given unicode URI string.
-
-        :param str uri_string: Unicode URI to be parsed into a reference.
-        :param str encoding: The encoding of the string provided
-        :returns: :class:`URIReference` or subclass thereof
-        """
-        uri_string = compat.to_str(uri_string, encoding)
-
-        split_uri = misc.URI_MATCHER.match(uri_string).groupdict()
-        return cls(
-            split_uri['scheme'], split_uri['authority'],
-            normalizers.encode_component(split_uri['path'], encoding),
-            normalizers.encode_component(split_uri['query'], encoding),
-            normalizers.encode_component(split_uri['fragment'], encoding),
-            encoding,
-        )
-
-    def authority_info(self):
-        """Return a dictionary with the ``userinfo``, ``host``, and ``port``.
-
-        If the authority is not valid, it will raise a
-        :class:`~rfc3986.exceptions.InvalidAuthority` Exception.
-
-        :returns:
-            ``{'userinfo': 'username:password', 'host': 'www.example.com',
-            'port': '80'}``
-        :rtype: dict
-        :raises rfc3986.exceptions.InvalidAuthority:
-            If the authority is not ``None`` and can not be parsed.
-        """
-        if not self.authority:
-            return {'userinfo': None, 'host': None, 'port': None}
-
-        match = misc.SUBAUTHORITY_MATCHER.match(self.authority)
-
-        if match is None:
-            # In this case, we have an authority that was parsed from the URI
-            # Reference, but it cannot be further parsed by our
-            # misc.SUBAUTHORITY_MATCHER. In this case it must not be a valid
-            # authority.
-            raise exc.InvalidAuthority(self.authority.encode(self.encoding))
-
-        # We had a match, now let's ensure that it is actually a valid host
-        # address if it is IPv4
-        matches = match.groupdict()
-        host = matches.get('host')
-
-        if (host and misc.IPv4_MATCHER.match(host) and not
-                validators.valid_ipv4_host_address(host)):
-            # If we have a host, it appears to be IPv4 and it does not have
-            # valid bytes, it is an InvalidAuthority.
-            raise exc.InvalidAuthority(self.authority.encode(self.encoding))
-
-        return matches
-
-    @property
-    def host(self):
-        """If present, a string representing the host."""
-        try:
-            authority = self.authority_info()
-        except exc.InvalidAuthority:
-            return None
-        return authority['host']
-
-    @property
-    def port(self):
-        """If present, the port extracted from the authority."""
-        try:
-            authority = self.authority_info()
-        except exc.InvalidAuthority:
-            return None
-        return authority['port']
-
-    @property
-    def userinfo(self):
-        """If present, the userinfo extracted from the authority."""
-        try:
-            authority = self.authority_info()
-        except exc.InvalidAuthority:
-            return None
-        return authority['userinfo']
-
-    def is_absolute(self):
-        """Determine if this URI Reference is an absolute URI.
-
-        See http://tools.ietf.org/html/rfc3986#section-4.3 for explanation.
-
-        :returns: ``True`` if it is an absolute URI, ``False`` otherwise.
-        :rtype: bool
-        """
-        return bool(misc.ABSOLUTE_URI_MATCHER.match(self.unsplit()))
-
-    def is_valid(self, **kwargs):
-        """Determine if the URI is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the :class:`~rfc3986.validators.Validator` object instead.
-
-        :param bool require_scheme: Set to ``True`` if you wish to require the
-            presence of the scheme component.
-        :param bool require_authority: Set to ``True`` if you wish to require
-            the presence of the authority component.
-        :param bool require_path: Set to ``True`` if you wish to require the
-            presence of the path component.
-        :param bool require_query: Set to ``True`` if you wish to require the
-            presence of the query component.
-        :param bool require_fragment: Set to ``True`` if you wish to require
-            the presence of the fragment component.
-        :returns: ``True`` if the URI is valid. ``False`` otherwise.
-        :rtype: bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        validators = [
-            (self.scheme_is_valid, kwargs.get('require_scheme', False)),
-            (self.authority_is_valid, kwargs.get('require_authority', False)),
-            (self.path_is_valid, kwargs.get('require_path', False)),
-            (self.query_is_valid, kwargs.get('require_query', False)),
-            (self.fragment_is_valid, kwargs.get('require_fragment', False)),
-            ]
-        return all(v(r) for v, r in validators)
-
-    def authority_is_valid(self, require=False):
-        """Determine if the authority component is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the :class:`~rfc3986.validators.Validator` object instead.
-
-        :param bool require:
-            Set to ``True`` to require the presence of this component.
-        :returns:
-            ``True`` if the authority is valid. ``False`` otherwise.
-        :rtype:
-            bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        try:
-            self.authority_info()
-        except exc.InvalidAuthority:
-            return False
-
-        return validators.authority_is_valid(
-            self.authority,
-            host=self.host,
-            require=require,
-        )
-
-    def scheme_is_valid(self, require=False):
-        """Determine if the scheme component is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the :class:`~rfc3986.validators.Validator` object instead.
-
-        :param str require: Set to ``True`` to require the presence of this
-            component.
-        :returns: ``True`` if the scheme is valid. ``False`` otherwise.
-        :rtype: bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        return validators.scheme_is_valid(self.scheme, require)
-
-    def path_is_valid(self, require=False):
-        """Determine if the path component is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the :class:`~rfc3986.validators.Validator` object instead.
-
-        :param str require: Set to ``True`` to require the presence of this
-            component.
-        :returns: ``True`` if the path is valid. ``False`` otherwise.
-        :rtype: bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        return validators.path_is_valid(self.path, require)
-
-    def query_is_valid(self, require=False):
-        """Determine if the query component is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the :class:`~rfc3986.validators.Validator` object instead.
-
-        :param str require: Set to ``True`` to require the presence of this
-            component.
-        :returns: ``True`` if the query is valid. ``False`` otherwise.
-        :rtype: bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        return validators.query_is_valid(self.query, require)
-
-    def fragment_is_valid(self, require=False):
-        """Determine if the fragment component is valid.
-
-        .. deprecated:: 1.1.0
-
-            Use the Validator object instead.
-
-        :param str require: Set to ``True`` to require the presence of this
-            component.
-        :returns: ``True`` if the fragment is valid. ``False`` otherwise.
-        :rtype: bool
-        """
-        warnings.warn("Please use rfc3986.validators.Validator instead. "
-                      "This method will be eventually removed.",
-                      DeprecationWarning)
-        return validators.fragment_is_valid(self.fragment, require)
-
     def normalize(self):
         """Normalize this reference as described in Section 6.2.2.
 
@@ -357,136 +133,21 @@ class URIReference(namedtuple('URIReference', misc.URI_COMPONENTS)):
                             normalizers.normalize_fragment(self.fragment),
                             self.encoding)
 
-    def normalized_equality(self, other_ref):
-        """Compare this URIReference to another URIReference.
+    @classmethod
+    def from_string(cls, uri_string, encoding='utf-8'):
+        """Parse a URI reference from the given unicode URI string.
 
-        :param URIReference other_ref: (required), The reference with which
-            we're comparing.
-        :returns: ``True`` if the references are equal, ``False`` otherwise.
-        :rtype: bool
+        :param str uri_string: Unicode URI to be parsed into a reference.
+        :param str encoding: The encoding of the string provided
+        :returns: :class:`URIReference` or subclass thereof
         """
-        return tuple(self.normalize()) == tuple(other_ref.normalize())
+        uri_string = compat.to_str(uri_string, encoding)
 
-    def resolve_with(self, base_uri, strict=False):
-        """Use an absolute URI Reference to resolve this relative reference.
-
-        Assuming this is a relative reference that you would like to resolve,
-        use the provided base URI to resolve it.
-
-        See http://tools.ietf.org/html/rfc3986#section-5 for more information.
-
-        :param base_uri: Either a string or URIReference. It must be an
-            absolute URI or it will raise an exception.
-        :returns: A new URIReference which is the result of resolving this
-            reference using ``base_uri``.
-        :rtype: :class:`URIReference`
-        :raises rfc3986.exceptions.ResolutionError:
-            If the ``base_uri`` is not an absolute URI.
-        """
-        if not isinstance(base_uri, URIReference):
-            base_uri = URIReference.from_string(base_uri)
-
-        if not base_uri.is_absolute():
-            raise exc.ResolutionError(base_uri)
-
-        # This is optional per
-        # http://tools.ietf.org/html/rfc3986#section-5.2.1
-        base_uri = base_uri.normalize()
-
-        # The reference we're resolving
-        resolving = self
-
-        if not strict and resolving.scheme == base_uri.scheme:
-            resolving = resolving.copy_with(scheme=None)
-
-        # http://tools.ietf.org/html/rfc3986#page-32
-        if resolving.scheme is not None:
-            target = resolving.copy_with(
-                path=normalizers.normalize_path(resolving.path)
-            )
-        else:
-            if resolving.authority is not None:
-                target = resolving.copy_with(
-                    scheme=base_uri.scheme,
-                    path=normalizers.normalize_path(resolving.path)
-                )
-            else:
-                if resolving.path is None:
-                    if resolving.query is not None:
-                        query = resolving.query
-                    else:
-                        query = base_uri.query
-                    target = resolving.copy_with(
-                        scheme=base_uri.scheme,
-                        authority=base_uri.authority,
-                        path=base_uri.path,
-                        query=query
-                    )
-                else:
-                    if resolving.path.startswith('/'):
-                        path = normalizers.normalize_path(resolving.path)
-                    else:
-                        path = normalizers.normalize_path(
-                            misc.merge_paths(base_uri, resolving.path)
-                        )
-                    target = resolving.copy_with(
-                        scheme=base_uri.scheme,
-                        authority=base_uri.authority,
-                        path=path,
-                        query=resolving.query
-                    )
-        return target
-
-    def unsplit(self):
-        """Create a URI string from the components.
-
-        :returns: The URI Reference reconstituted as a string.
-        :rtype: str
-        """
-        # See http://tools.ietf.org/html/rfc3986#section-5.3
-        result_list = []
-        if self.scheme:
-            result_list.extend([self.scheme, ':'])
-        if self.authority:
-            result_list.extend(['//', self.authority])
-        if self.path:
-            result_list.append(self.path)
-        if self.query is not None:
-            result_list.extend(['?', self.query])
-        if self.fragment is not None:
-            result_list.extend(['#', self.fragment])
-        return ''.join(result_list)
-
-    def copy_with(self, scheme=misc.UseExisting, authority=misc.UseExisting,
-                  path=misc.UseExisting, query=misc.UseExisting,
-                  fragment=misc.UseExisting):
-        """Create a copy of this reference with the new components.
-
-        :param str scheme:
-            (optional) The scheme to use for the new reference.
-        :param str authority:
-            (optional) The authority to use for the new reference.
-        :param str path:
-            (optional) The path to use for the new reference.
-        :param str query:
-            (optional) The query to use for the new reference.
-        :param str fragment:
-            (optional) The fragment to use for the new reference.
-        :returns:
-            New URIReference with provided components.
-        :rtype:
-            URIReference
-        """
-        attributes = {
-            'scheme': scheme,
-            'authority': authority,
-            'path': path,
-            'query': query,
-            'fragment': fragment,
-        }
-        for key, value in list(attributes.items()):
-            if value is misc.UseExisting:
-                del attributes[key]
-        uri = self._replace(**attributes)
-        uri.encoding = self.encoding
-        return uri
+        split_uri = misc.URI_MATCHER.match(uri_string).groupdict()
+        return cls(
+            split_uri['scheme'], split_uri['authority'],
+            normalizers.encode_component(split_uri['path'], encoding),
+            normalizers.encode_component(split_uri['query'], encoding),
+            normalizers.encode_component(split_uri['fragment'], encoding),
+            encoding,
+        )

--- a/src/urllib3/packages/rfc3986/validators.py
+++ b/src/urllib3/packages/rfc3986/validators.py
@@ -304,8 +304,28 @@ def authority_is_valid(authority, host=None, require=False):
         bool
     """
     validated = is_valid(authority, misc.SUBAUTHORITY_MATCHER, require)
+    if validated and host is not None:
+        return host_is_valid(host, require)
+    return validated
+
+
+def host_is_valid(host, require=False):
+    """Determine if the host string is valid.
+
+    :param str host:
+        The host to validate.
+    :param bool require:
+        (optional) Specify if host must not be None.
+    :returns:
+        ``True`` if valid, ``False`` otherwise
+    :rtype:
+        bool
+    """
+    validated = is_valid(host, misc.HOST_MATCHER, require)
     if validated and host is not None and misc.IPv4_MATCHER.match(host):
         return valid_ipv4_host_address(host)
+    elif validated and host is not None and misc.IPv6_MATCHER.match(host):
+        return misc.IPv6_NO_RFC4007_MATCHER.match(host) is not None
     return validated
 
 
@@ -395,7 +415,9 @@ def subauthority_component_is_valid(uri, component):
 
     # If we can parse the authority into sub-components and we're not
     # validating the port, we can assume it's valid.
-    if component != 'port':
+    if component == 'host':
+        return host_is_valid(subauthority_dict['host'])
+    elif component != 'port':
         return True
 
     try:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -130,12 +130,24 @@ class TestUtil(object):
         with pytest.raises(LocationParseError):
             get_host(location)
 
+    @pytest.mark.parametrize('url', [
+        'http://user\\@google.com',
+        'http://google\\.com',
+        'user\\@google.com',
+        'http://google.com#fragment#',
+        'http://user@user@google.com/',
+    ])
+    def test_invalid_url(self, url):
+        with pytest.raises(LocationParseError):
+            parse_url(url)
+
     @pytest.mark.parametrize('url, expected_normalized_url', [
         ('HTTP://GOOGLE.COM/MAIL/', 'http://google.com/MAIL/'),
         ('HTTP://JeremyCline:Hunter2@Example.com:8080/',
          'http://JeremyCline:Hunter2@example.com:8080/'),
         ('HTTPS://Example.Com/?Key=Value', 'https://example.com/?Key=Value'),
         ('Https://Example.Com/#Fragment', 'https://example.com/#Fragment'),
+        ('[::Ff%etH0%Ff]/%ab%Af', '[::ff%25etH0%Ff]/%AB%AF'),
     ])
     def test_parse_url_normalization(self, url, expected_normalized_url):
         """Assert parse_url normalizes the scheme/host, and only the scheme/host"""
@@ -154,8 +166,7 @@ class TestUtil(object):
         # Path/query/fragment
         ('', Url()),
         ('/', Url(path='/')),
-        ('/abc/../def', Url(path="/abc/../def")),
-        ('#?/!google.com/?foo#bar', Url(path='', fragment='?/!google.com/?foo#bar')),
+        ('#?/!google.com/?foo', Url(path='', fragment='?/!google.com/?foo')),
         ('/foo', Url(path='/foo')),
         ('/foo?bar=baz', Url(path='/foo', query='bar=baz')),
         ('/foo?bar=baz#banana?apple/orange', Url(path='/foo',
@@ -172,10 +183,10 @@ class TestUtil(object):
         # Auth
         ('http://foo:bar@localhost/', Url('http', auth='foo:bar', host='localhost', path='/')),
         ('http://foo@localhost/', Url('http', auth='foo', host='localhost', path='/')),
-        ('http://foo:bar@baz@localhost/', Url('http',
-                                              auth='foo:bar@baz',
-                                              host='localhost',
-                                              path='/')),
+        ('http://foo:bar@localhost/', Url('http',
+                                          auth='foo:bar',
+                                          host='localhost',
+                                          path='/')),
 
         # Unicode type (Python 2.x)
         (u'http://foo:bar@localhost/', Url(u'http',
@@ -193,9 +204,16 @@ class TestUtil(object):
         ('?', Url(path='', query='')),
         ('#', Url(path='', fragment='')),
 
+        # Path normalization
+        ('/abc/../def', Url(path="/def")),
+
         # Empty Port
         ('http://google.com:', Url('http', host='google.com')),
         ('http://google.com:/', Url('http', host='google.com', path='/')),
+
+        # Uppercase IRI
+        (u'http://Königsgäßchen.de/straße',
+         Url('http', host='xn--knigsgchen-b4a3dun.de', path='/stra%C3%9Fe'))
     ]
 
     @pytest.mark.parametrize(
@@ -209,6 +227,23 @@ class TestUtil(object):
     @pytest.mark.parametrize('url, expected_url', parse_url_host_map)
     def test_unparse_url(self, url, expected_url):
         assert url == expected_url.url
+
+    @pytest.mark.parametrize(
+        ['url', 'expected_url'],
+        [
+            # RFC 3986 5.2.4
+            ('/abc/../def', Url(path="/def")),
+            ('/..', Url(path="/")),
+            ('/./abc/./def/', Url(path='/abc/def/')),
+            ('/.', Url(path='/')),
+            ('/./', Url(path='/')),
+            ('/abc/./.././d/././e/.././f/./../../ghi', Url(path='/ghi'))
+        ]
+    )
+    def test_parse_and_normalize_url_paths(self, url, expected_url):
+        actual_url = parse_url(url)
+        assert actual_url == expected_url
+        assert actual_url.url == expected_url.url
 
     def test_parse_url_invalid_IPv6(self):
         with pytest.raises(LocationParseError):
@@ -259,12 +294,36 @@ class TestUtil(object):
 
         # CVE-2016-5699
         ("http://127.0.0.1%0d%0aConnection%3a%20keep-alive",
-         Url("http", host="127.0.0.1%0d%0aConnection%3a%20keep-alive")),
+         Url("http", host="127.0.0.1%0d%0aconnection%3a%20keep-alive")),
 
         # NodeJS unicode -> double dot
         (u"http://google.com/\uff2e\uff2e/abc", Url("http",
                                                     host="google.com",
-                                                    path='/%ef%bc%ae%ef%bc%ae/abc'))
+                                                    path='/%EF%BC%AE%EF%BC%AE/abc')),
+
+        # Scheme without ://
+        ("javascript:a='@google.com:12345/';alert(0)",
+         Url(scheme="javascript",
+             path="a='@google.com:12345/';alert(0)")),
+
+        ("//google.com/a/b/c", Url(host="google.com", path="/a/b/c")),
+
+        # International URLs
+        (u'http://ヒ:キ@ヒ.abc.ニ/ヒ?キ#ワ', Url(u'http',
+                                          host=u'xn--pdk.abc.xn--idk',
+                                          auth=u'%E3%83%92:%E3%82%AD',
+                                          path=u'/%E3%83%92',
+                                          query=u'%E3%82%AD',
+                                          fragment=u'%E3%83%AF')),
+
+        # Injected headers (CVE-2016-5699, CVE-2019-9740, CVE-2019-9947)
+        ("10.251.0.83:7777?a=1 HTTP/1.1\r\nX-injected: header",
+         Url(host='10.251.0.83', port=7777, path='',
+             query='a=1%20HTTP/1.1%0D%0AX-injected:%20header')),
+
+        ("http://127.0.0.1:6379?\r\nSET test failure12\r\n:8080/test/?test=a",
+         Url(scheme='http', host='127.0.0.1', port=6379, path='',
+             query='%0D%0ASET%20test%20failure12%0D%0A:8080/test/?test=a')),
     ]
 
     @pytest.mark.parametrize("url, expected_url", url_vulnerabilities)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8-py3, py27, py34, py35, py36, py37, py38, pypy, pypy3, py{27,37}-nobrotli
+envlist = flake8-py3, py27, py34, py35, py36, py37, py38, pypy, pypy3, py{27,37}-nobrotli, py{27,37}-google-brotli
 
 # PEP 518 support
 isolated_build = True
@@ -22,6 +22,18 @@ passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS TRAVIS_I
 
 [testenv:.package]
 deps=
+
+[testenv:py37-google-brotli]
+extras = socks,secure
+deps =
+    {[testenv]deps}
+    Brotli
+
+[testenv:py27-google-brotli]
+extras = socks,secure
+deps =
+    {[testenv]deps}
+    Brotli
 
 [testenv:py27-nobrotli]
 extras = socks,secure


### PR DESCRIPTION
With this PR, we support Google's Brotli package and parse URLs with the rfc3986 package. There were only conflicts in response.py and connectionpool.py (and .travis.yml and tox.ini). As I can see the future, I can tell you that rfc3986 will be dropped in a later PR, so don't worry too much about it!

What's left before catching up with the master branch:
  * switch from tox to nox
  * switch to black
  * switch to pure pytest:
    * assertions
    * unittest removal
    * replacing addCleanup with context managers
  * TLS 1.3 post-handshake authentication