### PR TITLE
Remove HTTPHeaderDict.from_httplib

### DIFF
--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -522,7 +522,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         :param \\**response_kw:
             Additional parameters are passed to
-            :meth:`urllib3.response.HTTPResponse.from_httplib`
+            :meth:`urllib3.response.HTTPResponse.from_base`
         """
         if headers is None:
             headers = self.headers

--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -15,7 +15,6 @@ except ImportError:  # Platform-specific: No threads available
 
 
 from collections import OrderedDict
-from .exceptions import InvalidHeader
 from .packages.six import iterkeys, itervalues, PY3
 
 
@@ -299,31 +298,3 @@ class HTTPHeaderDict(MutableMapping):
 
     def items(self):
         return list(self.iteritems())
-
-    @classmethod
-    def from_httplib(cls, message):  # Python 2
-        """Read headers from a Python 2 httplib message object."""
-        # python2.7 does not expose a proper API for exporting multiheaders
-        # efficiently. This function re-reads raw lines from the message
-        # object and extracts the multiheaders properly.
-        obs_fold_continued_leaders = (' ', '\t')
-        headers = []
-
-        for line in message.headers:
-            if line.startswith(obs_fold_continued_leaders):
-                if not headers:
-                    # We received a header line that starts with OWS as described
-                    # in RFC-7230 S3.2.4. This indicates a multiline header, but
-                    # there exists no previous header to which we can attach it.
-                    raise InvalidHeader(
-                        'Header continuation with no previous header: %s' % line
-                    )
-                else:
-                    key, value = headers[-1]
-                    headers[-1] = (key, value + ' ' + line.strip())
-                    continue
-
-            key, value = line.split(':', 1)
-            headers.append((key, value.strip()))
-
-        return cls(headers)


### PR DESCRIPTION
Fixes #109

> We're not using httplib (the old name for http.client), so
> all mentions of from_httplib can be removed from the code.