### PR TITLE
Merge from master (May 23th, 2019)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+tidelift: pypi/urllib3

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,4 +130,4 @@ stages:
 
   # Deploy on any tags
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present AND tag =~ /^(\d+\.\d+(?:.\d+)?)$/ AND repo = urllib3/urllib3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,21 @@ Upcoming 2.0 Changes
 
 * Removed ``BodyNotHttplibCompatible`` and ``ResponseNotChunked`` exceptions.
 
+dev (master)
+------------
+
+* Upgrade bundled rfc3986 to 1.3.2. (Pull #1609, Issue #1605)
+
+
+1.25.2 (2019-04-28)
+-------------------
+
+* Change ``is_ipaddress`` to not detect IPvFuture addresses. (Pull #1583)
+
+* Change ``parse_url`` to percent-encode invalid characters within the
+  path, query, and target components. (Pull #1586)
+
+
 1.25.1 (2019-04-24)
 -------------------
 
@@ -60,6 +75,10 @@ Upcoming 2.0 Changes
 
 * Implemented a more efficient ``HTTPResponse.__iter__()`` method. (Issue #1483)
 
+1.24.3 (2019-05-01)
+-------------------
+
+* Apply fix for CVE-2019-9740. (Pull #1591)
 
 1.24.2 (2019-04-17)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ Upcoming 2.0 Changes
 dev (master)
 ------------
 
+* Change ``HTTPSConnection`` to load system CA certificates
+  when ``ca_certs``, ``ca_cert_dir``, and ``ssl_context`` are
+  unspecified. (Pull #1608, Issue #1603)
+
 * Upgrade bundled rfc3986 to 1.3.2. (Pull #1609, Issue #1605)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -193,7 +193,7 @@ In chronological order:
 * Shige Takeda <smtakeda@gmail.com>
   * Started Recipes documentation and added a recipe about handling concatenated gzip data in HTTP response
 
-* Jesse Shapiro <jesse@jesseshapiro.net>
+* Jess Shapiro <jesse@jesseshapiro.net>
   * Various character-encoding fixes/tweaks
   * Disabling IPv6 DNS when IPv6 connections not supported
 
@@ -244,8 +244,8 @@ In chronological order:
   * Fix ``util.selectors._fileobj_to_fd`` to accept ``long``.
   * Update appveyor tox setup to use the 64bit python.
 
-* Akamai (through Jesse Shapiro) <jshapiro@akamai.com>
-  * Ongoing maintenance
+* Akamai (through Jess Shapiro) <jshapiro@akamai.com>
+  * Ongoing maintenance; 2017-2018
 
 * Dominique Leuenberger <dimstar@opensuse.org>
   * Minor fixes in the test suite

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Maintainers
 
 - `@theacodes <https://github.com/theacodes>`_ (Thea Flowers)
 - `@sethmlarson <https://github.com/sethmlarson>`_ (Seth M. Larson)
-- `@haikuginger <https://github.com/haikuginger>`_ (Jesse Shapiro)
+- `@haikuginger <https://github.com/haikuginger>`_ (Jess Shapiro)
 - `@lukasa <https://github.com/lukasa>`_ (Cory Benfield)
 - `@sigmavirus24 <https://github.com/sigmavirus24>`_ (Ian Cordasco)
 - `@shazow <https://github.com/shazow>`_ (Andrey Petrov)
@@ -129,5 +129,5 @@ Sponsors include:
 
 - Google Cloud Platform (2018-present), sponsors `@theacodes <https://github.com/theacodes>`_'s work on an ongoing basis
 - Abbott (2018-present), sponsors `@sethmlarson <https://github.com/sethmlarson>`_'s work on an ongoing basis
-- Akamai (2017-present), sponsors `@haikuginger <https://github.com/haikuginger>`_'s work on an ongoing basis
+- Akamai (2017-2018), sponsored `@haikuginger <https://github.com/haikuginger>`_'s work on urllib3
 - Hewlett Packard Enterprise (2016-2017), sponsored `@Lukasa’s <https://github.com/Lukasa>`_ work on urllib3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,10 @@ pytest-cov==2.6.0
 h11==0.8.0
 cryptography==2.6.1
 pluggy==0.8.0
+
+# https://github.com/ionelmc/python-lazy-object-proxy/issues/30
+lazy-object-proxy==1.4.0
+
 # https://github.com/GoogleCloudPlatform/python-repo-tools/issues/23
 pylint<2.0;python_version<="2.7"
 gcp-devrel-py-tools

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,8 +77,8 @@ named ``release-x.x`` where ``x.x`` is the version of the proposed release.
 - Integration tests are run against the release candidate on Travis. From here on all
   the steps below will be handled by a maintainer so unless you receive review comments
   you are done here.
-- Once the pull request is squash merged into master the merging maintainer the
-  pull request will tag the merge commit with the version number:
+- Once the pull request is squash merged into master the merging maintainer
+  will tag the merge commit with the version number:
 
   - ``git tag -a 1.24.1 [commit sha]``
   - ``git push origin master --tags``

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -85,6 +85,13 @@ def _build_context(context, keyfile, certfile, cert_reqs, key_password,
             ssl_version=resolve_ssl_version(ssl_version),
             cert_reqs=resolve_cert_reqs(cert_reqs)
         )
+
+        # Try to load OS default certs if none are given.
+        # Works well on Windows (requires Python3.4+)
+        if (not ca_certs and not ca_cert_dir
+                and hasattr(context, 'load_default_certs')):
+            context.load_default_certs()
+
     context = merge_context_settings(
         context, keyfile=keyfile, certfile=certfile,
         cert_reqs=cert_reqs, key_password=key_password,

--- a/src/urllib3/packages/rfc3986/__init__.py
+++ b/src/urllib3/packages/rfc3986/__init__.py
@@ -36,7 +36,7 @@ __author__ = 'Ian Stapleton Cordasco'
 __author_email__ = 'graffatcolmingov@gmail.com'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Rackspace'
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 __all__ = (
     'ParseResult',

--- a/src/urllib3/packages/rfc3986/misc.py
+++ b/src/urllib3/packages/rfc3986/misc.py
@@ -110,28 +110,6 @@ ISUBAUTHORITY_MATCHER = re.compile((
              abnf_regexp.PORT_RE), re.UNICODE)
 
 
-IHOST_MATCHER = re.compile('^' + abnf_regexp.IHOST_RE + '$', re.UNICODE)
-
-IPATH_MATCHER = re.compile(abnf_regexp.IPATH_RE, re.UNICODE)
-
-IQUERY_MATCHER = re.compile(abnf_regexp.IQUERY_RE, re.UNICODE)
-
-IFRAGMENT_MATCHER = re.compile(abnf_regexp.IFRAGMENT_RE, re.UNICODE)
-
-
-RELATIVE_IRI_MATCHER = re.compile(u'^%s(?:\\?%s)?(?:%s)?$' % (
-    abnf_regexp.IRELATIVE_PART_RE,
-    abnf_regexp.IQUERY_RE,
-    abnf_regexp.IFRAGMENT_RE
-), re.UNICODE)
-
-ABSOLUTE_IRI_MATCHER = re.compile(u'^%s:%s(?:\\?%s)?$' % (
-    abnf_regexp.COMPONENT_PATTERN_DICT['scheme'],
-    abnf_regexp.IHIER_PART_RE,
-    abnf_regexp.IQUERY_RE[1:-1]
-), re.UNICODE)
-
-
 # Path merger as defined in http://tools.ietf.org/html/rfc3986#section-5.2.3
 def merge_paths(base_uri, relative_path):
     """Merge a base URI's path with a relative URI's path."""

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -52,11 +52,10 @@ _const_compare_digest = getattr(hmac, 'compare_digest',
 # Borrow rfc3986's regular expressions for IPv4
 # and IPv6 addresses for use in is_ipaddress()
 _IP_ADDRESS_REGEX = re.compile(
-    r'^(?:%s|%s|%s|%s)$' % (
+    r'^(?:%s|%s|%s)$' % (
         abnf_regexp.IPv4_RE,
         abnf_regexp.IPv6_RE,
-        abnf_regexp.IPv6_ADDRZ_RE,
-        abnf_regexp.IPv_FUTURE_RE
+        abnf_regexp.IPv6_ADDRZ_RFC4007_RE
     )
 )
 
@@ -442,7 +441,8 @@ def match_hostname(cert, asserted_hostname):
 
 
 def is_ipaddress(hostname):
-    """Detects whether the hostname given is an IP address.
+    """Detects whether the hostname given is an IPv4 or IPv6 address.
+    Also detects IPv6 addresses with Zone IDs.
 
     :param str hostname: Hostname to examine.
     :return: True if the hostname is an IP address, False otherwise.

--- a/src/urllib3/util/ssl_.py
+++ b/src/urllib3/util/ssl_.py
@@ -326,9 +326,6 @@ def merge_context_settings(context, keyfile=None, certfile=None,
             if e.errno == errno.ENOENT:
                 raise SSLError(e)
             raise
-    elif getattr(context, 'load_default_certs', None) is not None:
-        # try to load OS default certs; works well on Windows (require Python3.4+)
-        context.load_default_certs()
 
     # Attempt to detect if we get the goofy behavior of the
     # keyfile being encrypted and OpenSSL asking for the

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -6,6 +6,7 @@ from ..exceptions import LocationParseError
 from ..packages import six, rfc3986
 from ..packages.rfc3986.exceptions import RFC3986Exception, ValidationError
 from ..packages.rfc3986.validators import Validator
+from ..packages.rfc3986 import abnf_regexp, normalizers, compat, misc
 
 
 url_attrs = ['scheme', 'auth', 'host', 'port', 'path', 'query', 'fragment']
@@ -16,6 +17,9 @@ NORMALIZABLE_SCHEMES = ('http', 'https', None)
 
 # Regex for detecting URLs with schemes. RFC 3986 Section 3.1
 SCHEME_REGEX = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+\-]*:|/)")
+
+PATH_CHARS = abnf_regexp.UNRESERVED_CHARS_SET | abnf_regexp.SUB_DELIMITERS_SET | {':', '@', '/'}
+QUERY_CHARS = FRAGMENT_CHARS = PATH_CHARS | {'?'}
 
 
 class Url(namedtuple('Url', url_attrs)):
@@ -136,6 +140,37 @@ def split_first(s, delims):
     return s[:min_idx], s[min_idx + 1:], min_delim
 
 
+def _encode_invalid_chars(component, allowed_chars, encoding='utf-8'):
+    """Percent-encodes a URI component without reapplying
+    onto an already percent-encoded component. Based on
+    rfc3986.normalizers.encode_component()
+    """
+    if component is None:
+        return component
+
+    # Try to see if the component we're encoding is already percent-encoded
+    # so we can skip all '%' characters but still encode all others.
+    percent_encodings = len(normalizers.PERCENT_MATCHER.findall(
+                            compat.to_str(component, encoding)))
+
+    uri_bytes = component.encode('utf-8', 'surrogatepass')
+    is_percent_encoded = percent_encodings == uri_bytes.count(b'%')
+
+    encoded_component = bytearray()
+
+    for i in range(0, len(uri_bytes)):
+        # Will return a single character bytestring on both Python 2 & 3
+        byte = uri_bytes[i:i+1]
+        byte_ord = ord(byte)
+        if ((is_percent_encoded and byte == b'%')
+                or (byte_ord < 128 and byte.decode() in allowed_chars)):
+            encoded_component.extend(byte)
+            continue
+        encoded_component.extend('%{0:02x}'.format(byte_ord).encode().upper())
+
+    return encoded_component.decode(encoding)
+
+
 def parse_url(url):
     """
     Given a url, return a parsed :class:`.Url` namedtuple. Best-effort is
@@ -160,8 +195,6 @@ def parse_url(url):
         return Url()
 
     is_string = not isinstance(url, six.binary_type)
-    if not is_string:
-        url = url.decode("utf-8")
 
     # RFC 3986 doesn't like URLs that have a host but don't start
     # with a scheme and we support URLs like that so we need to
@@ -170,11 +203,6 @@ def parse_url(url):
     # off and given an empty scheme anyways.
     if not SCHEME_REGEX.search(url):
         url = "//" + url
-
-    try:
-        iri_ref = rfc3986.IRIReference.from_string(url, encoding="utf-8")
-    except (ValueError, RFC3986Exception):
-        six.raise_from(LocationParseError(url), None)
 
     def idna_encode(name):
         if name and any([ord(x) > 128 for x in name]):
@@ -188,8 +216,18 @@ def parse_url(url):
                 raise LocationParseError(u"Name '%s' is not a valid IDNA label" % name)
         return name
 
-    has_authority = iri_ref.authority is not None
-    uri_ref = iri_ref.encode(idna_encoder=idna_encode)
+    try:
+        split_iri = misc.IRI_MATCHER.match(compat.to_str(url)).groupdict()
+        iri_ref = rfc3986.IRIReference(
+            split_iri['scheme'], split_iri['authority'],
+            _encode_invalid_chars(split_iri['path'], PATH_CHARS),
+            _encode_invalid_chars(split_iri['query'], QUERY_CHARS),
+            _encode_invalid_chars(split_iri['fragment'], FRAGMENT_CHARS)
+        )
+        has_authority = iri_ref.authority is not None
+        uri_ref = iri_ref.encode(idna_encoder=idna_encode)
+    except (ValueError, RFC3986Exception):
+        return six.raise_from(LocationParseError(url), None)
 
     # rfc3986 strips the authority if it's invalid
     if has_authority and uri_ref.authority is None:
@@ -209,7 +247,7 @@ def parse_url(url):
             *validator.COMPONENT_NAMES
         ).validate(uri_ref)
     except ValidationError:
-        six.raise_from(LocationParseError(url), None)
+        return six.raise_from(LocationParseError(url), None)
 
     # For the sake of backwards compatibility we put empty
     # string values for path if there are any defined values

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -8,11 +8,21 @@ from urllib3.exceptions import SNIMissingWarning
 
 
 @pytest.mark.parametrize('addr', [
+    # IPv6
     '::1',
     '::',
+    'FE80::8939:7684:D84b:a5A4%251',
+
+    # IPv4
     '127.0.0.1',
     '8.8.8.8',
-    b'127.0.0.1'
+    b'127.0.0.1',
+
+    # IPv6 w/ Zone IDs
+    'FE80::8939:7684:D84b:a5A4%251',
+    b'FE80::8939:7684:D84b:a5A4%251',
+    'FE80::8939:7684:D84b:a5A4%19',
+    b'FE80::8939:7684:D84b:a5A4%19'
 ])
 def test_is_ipaddress_true(addr):
     assert ssl_.is_ipaddress(addr)
@@ -20,7 +30,9 @@ def test_is_ipaddress_true(addr):
 
 @pytest.mark.parametrize('addr', [
     'www.python.org',
-    b'www.python.org'
+    b'www.python.org',
+    'v2.sg.media-imdb.com',
+    b'v2.sg.media-imdb.com'
 ])
 def test_is_ipaddress_false(addr):
     assert not ssl_.is_ipaddress(addr)

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -117,7 +117,7 @@ def test_wrap_socket_given_context_no_load_default_certs():
 
 def test_wrap_socket_given_ca_certs_no_load_default_certs(monkeypatch):
     if platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2:
-        # https://github.com/testing-cabal/mock/pull/445/files
+        # https://github.com/testing-cabal/mock/issues/438
         pytest.xfail("fails with PyPy for Python 2 dues to funcsigs bug")
 
     context = mock.create_autospec(ssl_.SSLContext)

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -117,7 +117,9 @@ def test_wrap_socket_given_context_no_load_default_certs():
 
 def test_wrap_socket_given_ca_certs_no_load_default_certs(monkeypatch):
     if platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2:
-        pytest.xfail("test is expected to fail with PyPy 2")
+        # https://github.com/testing-cabal/mock/pull/445/files
+        pytest.xfail("fails with PyPy for Python 2 dues to funcsigs bug")
+
     context = mock.create_autospec(ssl_.SSLContext)
     context.load_default_certs = mock.Mock()
     context.options = 0

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -35,7 +35,10 @@ import io
 import select
 import socket
 import ssl
+import sys
 import mock
+import platform
+
 
 import pytest
 
@@ -1331,6 +1334,10 @@ class TestSSL(SocketDummyServerTestCase):
             context.load_default_certs.assert_called_with()
 
     def test_ssl_dont_load_default_certs_when_given(self):
+        if platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2:
+            # https://github.com/testing-cabal/mock/pull/445/files
+            pytest.xfail("fails with PyPy for Python 2 dues to funcsigs bug")
+
         def socket_handler(listener):
             sock = listener.accept()[0]
             ssl_sock = ssl.wrap_socket(sock,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1335,7 +1335,7 @@ class TestSSL(SocketDummyServerTestCase):
 
     def test_ssl_dont_load_default_certs_when_given(self):
         if platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2:
-            # https://github.com/testing-cabal/mock/pull/445/files
+            # https://github.com/testing-cabal/mock/issues/438
             pytest.xfail("fails with PyPy for Python 2 dues to funcsigs bug")
 
         def socket_handler(listener):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -35,6 +35,7 @@ import io
 import select
 import socket
 import ssl
+import mock
 
 import pytest
 
@@ -1292,6 +1293,83 @@ class TestSSL(SocketDummyServerTestCase):
         self.addCleanup(pool.close)
         response = pool.urlopen('GET', '/', retries=1)
         self.assertEqual(response.data, b'Success')
+
+    def test_ssl_load_default_certs_when_empty(self):
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            ssl_sock = ssl.wrap_socket(sock,
+                                       server_side=True,
+                                       keyfile=DEFAULT_CERTS['keyfile'],
+                                       certfile=DEFAULT_CERTS['certfile'],
+                                       ca_certs=DEFAULT_CA)
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += ssl_sock.recv(65536)
+
+            ssl_sock.send(b'HTTP/1.1 200 OK\r\n'
+                          b'Content-Type: text/plain\r\n'
+                          b'Content-Length: 5\r\n\r\n'
+                          b'Hello')
+
+            ssl_sock.close()
+            sock.close()
+
+        context = mock.create_autospec(ssl_.SSLContext)
+        context.load_default_certs = mock.Mock()
+        context.options = 0
+
+        with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):
+
+            self._start_server(socket_handler)
+            pool = HTTPSConnectionPool(self.host, self.port)
+            self.addCleanup(pool.close)
+
+            with self.assertRaises(MaxRetryError):
+                pool.request("GET", "/", timeout=0.01)
+
+            context.load_default_certs.assert_called_with()
+
+    def test_ssl_dont_load_default_certs_when_given(self):
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            ssl_sock = ssl.wrap_socket(sock,
+                                       server_side=True,
+                                       keyfile=DEFAULT_CERTS['keyfile'],
+                                       certfile=DEFAULT_CERTS['certfile'],
+                                       ca_certs=DEFAULT_CA)
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += ssl_sock.recv(65536)
+
+            ssl_sock.send(b'HTTP/1.1 200 OK\r\n'
+                          b'Content-Type: text/plain\r\n'
+                          b'Content-Length: 5\r\n\r\n'
+                          b'Hello')
+
+            ssl_sock.close()
+            sock.close()
+
+        context = mock.create_autospec(ssl_.SSLContext)
+        context.load_default_certs = mock.Mock()
+        context.options = 0
+
+        with mock.patch("urllib3.util.ssl_.SSLContext", lambda *_, **__: context):
+            for kwargs in [{"ca_certs": "/a"},
+                           {"ca_cert_dir": "/a"},
+                           {"ca_certs": "a", "ca_cert_dir": "a"},
+                           {"ssl_context": context}]:
+
+                self._start_server(socket_handler)
+
+                pool = HTTPSConnectionPool(self.host, self.port, **kwargs)
+                self.addCleanup(pool.close)
+
+                with self.assertRaises(MaxRetryError):
+                    pool.request("GET", "/", timeout=0.01)
+
+                context.load_default_certs.assert_not_called()
 
 
 class TestErrorWrapping(SocketDummyServerTestCase):


### PR DESCRIPTION
So this places us just before the switch to black and to pure pytest.

The only interesting change here is "Load system CA certificates by default on empty HTTPSConnection". I made sure that the tests passed, but did not test anything locally.

codecov is still broken for Travis (HTTP 400 error) and AppVeyor (coverage report not found).