### PR TITLE
First trio test

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ PySocks==1.7.1
 # https://github.com/Anorov/PySocks/issues/131
 win-inet-pton==1.1.0
 pytest==4.6.6
-pytest-random-order==1.0.4;python_version>="3.5"
+pytest-random-order==1.0.4;python_version>="3.6"
 pytest-timeout==1.3.3
 pytest-cov==2.7.1
 h11==0.8.0
@@ -16,10 +16,10 @@ flaky==3.6.1
 pylint<2.0;python_version<="2.7"
 gcp-devrel-py-tools
 
-# optional dependencies, only intended for use with Python 3.5+
-trio==0.13.0; python_version >= "3.5"
-pytest-trio==0.5.2;python_version>="3.5"
+# optional dependencies, only intended for use with Python 3.6+
+trio==0.13.0; python_version >= "3.6"
+pytest-trio==0.5.2;python_version>="3.6"
 # https://github.com/mhammond/pywin32/issues/1439
-pywin32!=226; python_version >= "3.5" and os_name == 'nt'
-twisted[tls]==19.2.0; python_version >= "3.5" and os_name != 'nt'
-twisted[tls,windows_platform]==19.2.0; python_version >= "3.5" and os_name == 'nt'
+pywin32!=226; python_version >= "3.6" and os_name == 'nt'
+twisted[tls]==19.2.0; python_version >= "3.6" and os_name != 'nt'
+twisted[tls,windows_platform]==19.2.0; python_version >= "3.6" and os_name == 'nt'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,8 @@ pylint<2.0;python_version<="2.7"
 gcp-devrel-py-tools
 
 # optional dependencies, only intended for use with Python 3.5+
-trio==0.3.0; python_version >= "3.5"
+trio==0.13.0; python_version >= "3.5"
+pytest-trio==0.5.2;python_version>="3.5"
 # https://github.com/mhammond/pywin32/issues/1439
 pywin32!=226; python_version >= "3.5" and os_name == 'nt'
 twisted[tls]==19.2.0; python_version >= "3.5" and os_name != 'nt'

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,4 @@ requires-dist =
 [tool:pytest]
 xfail_strict = true
 python_classes = Test *TestCase
+trio_mode = true

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -709,11 +709,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 **response_kw
             )
 
-        def drain_and_release_conn(response):
+        async def drain_and_release_conn(response):
             try:
                 # discard any remaining response body, the connection will be
                 # released back to the pool once the entire response is read
-                response.read()
+                await response.read()
             except (TimeoutError, SocketError, ProtocolError, BaseSSLError, SSLError):
                 pass
 
@@ -726,12 +726,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 if retries.raise_on_status:
                     # Drain and release the connection for this response, since
                     # we're not returning it to be released manually.
-                    drain_and_release_conn(response)
+                    await drain_and_release_conn(response)
                     raise
                 return response
 
             # drain and return the connection to the pool before recursing
-            drain_and_release_conn(response)
+            await drain_and_release_conn(response)
 
             retries.sleep(response)
             log.debug("Retry: %s", url)

--- a/src/urllib3/_async/poolmanager.py
+++ b/src/urllib3/_async/poolmanager.py
@@ -371,7 +371,7 @@ class PoolManager(RequestMethods):
 
         retries.sleep_for_retry(response)
         log.info("Redirecting %s -> %s", url, redirect_location)
-        return self.urlopen(method, redirect_location, **kw)
+        return await self.urlopen(method, redirect_location, **kw)
 
 
 class ProxyManager(PoolManager):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,5 @@
+import sys
+
+# We support Python 3.6+ for async code
+if sys.version_info[:2] < (3, 6):
+    collect_ignore_glob = ["*/async/*.py", "with_dummyserver/async/*.py"]

--- a/test/with_dummyserver/async/test_poolmanager.py
+++ b/test/with_dummyserver/async/test_poolmanager.py
@@ -1,0 +1,29 @@
+from dummyserver.testcase import HTTPDummyServerTestCase
+from urllib3 import AsyncPoolManager
+
+
+class TestPoolManager(HTTPDummyServerTestCase):
+    @classmethod
+    def setup_class(self):
+        super(TestPoolManager, self).setup_class()
+        self.base_url = "http://%s:%d" % (self.host, self.port)
+        self.base_url_alt = "http://%s:%d" % (self.host_alt, self.port)
+
+    async def test_redirect(self):
+        with AsyncPoolManager(backend="trio") as http:
+            r = await http.request(
+                "GET",
+                "%s/redirect" % self.base_url,
+                fields={"target": "%s/" % self.base_url},
+                redirect=False,
+            )
+            assert r.status == 303
+
+            r = await http.request(
+                "GET",
+                "%s/redirect" % self.base_url,
+                fields={"target": "%s/" % self.base_url},
+            )
+
+            assert r.status == 200
+            assert await r.read() == b"Dummy server!"


### PR DESCRIPTION
Okay, now that we have removed unittest, the diff to get a trio test to work is much smaller.

Remaining problems:

 * how do we avoid failing on Python 2 which can't even parse this file
 * how do we skip the tests on Python 3.5 which is not currently supported as we use native async generators? With a `onlyPy3`-like decoration, the test is not even run
 * how do we generate the sync test from the async ones and run against multiple backends?

I'm not planning to work on this until a few weeks, but ideas would be appreciated. cc @njsmith