### PR TITLE
Merge from master (September 20th, 2019)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,17 @@ Upcoming 2.0 Changes
   useful to persist them up to the user.
 
 * Removed ``BodyNotHttplibCompatible`` and ``ResponseNotChunked`` exceptions.
-dev (master)
-------------
+
+1.25.5 (2019-09-19)
+-------------------
+
+* Add mitigation for BPO-37428 affecting Python <3.7.4 and OpenSSL 1.1.1+ which
+  caused certificate verification to be enabled when using ``cert_reqs=CERT_NONE``.
+  (Issue #1682)
+
+
+1.25.4 (2019-09-19)
+-------------------
 
 * Propagate Retry-After header settings to subsequent retries. (Pull #1607)
 
@@ -39,6 +48,8 @@ dev (master)
 
 * Add support for ``HTTPResponse.auto_close = False`` which makes HTTP responses
   work well with BufferedReaders and other ``io`` module features. (Pull #1652)
+
+* Percent-encode invalid characters in URL for ``HTTPConnectionPool.request()`` (Pull #1673)
 
 
 1.25.3 (2019-05-23)

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ urllib3
         :target: https://tidelift.com/subscription/pkg/pypi-urllib3?utm_source=pypi-urllib3&utm_medium=referral&utm_campaign=docs
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/python/black
+    :target: https://github.com/psf/black
 
 urllib3 is a powerful, *sanity-friendly* HTTP client for Python. Much of the
 Python ecosystem already uses urllib3 and you should too.

--- a/_travis/downstream/requests-requirements.txt
+++ b/_travis/downstream/requests-requirements.txt
@@ -2,8 +2,8 @@ pytest-mock
 pysocks
 httpbin
 
-# kennethreitz/requests#5049
+# psf/requests#5049
 pytest<4.1
 
-# kennethreitz/requests#5004
+# psf/requests#5004
 pytest-httpbin==0.3.0

--- a/_travis/downstream/requests.sh
+++ b/_travis/downstream/requests.sh
@@ -4,7 +4,7 @@ set -exo pipefail
 
 case "${1}" in
     install)
-        git clone --depth 1 https://github.com/kennethreitz/requests
+        git clone --depth 1 https://github.com/psf/requests
         cd requests
         git rev-parse HEAD
         python -m pip install -r ${TRAVIS_BUILD_DIR}/_travis/downstream/requests-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 mock==2.0.0
 coverage~=4.5
-tox==3.9.0
 wheel==0.30.0
 tornado==5.1.1
 PySocks==1.6.8

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -17,7 +17,7 @@ from datetime import timedelta
 
 from urllib3.packages.six.moves.http_client import responses
 from urllib3.packages.six.moves.urllib.parse import urlsplit
-from urllib3.packages.six import binary_type
+from urllib3.packages.six import binary_type, ensure_str
 
 log = logging.getLogger(__name__)
 
@@ -207,6 +207,12 @@ class TestingApp(RequestHandler):
 
         headers = [("Connection", "keep-alive")]
         return Response("Keeping alive", headers=headers)
+
+    def echo_params(self, request):
+        params = sorted(
+            [(ensure_str(k), ensure_str(v)) for k, v in request.params.items()]
+        )
+        return Response(repr(params))
 
     def sleep(self, request):
         "Sleep for a specified amount of ``seconds``"

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,9 +21,8 @@ def tests_impl(session, extras="socks,secure,brotli"):
         "pytest",
         "-r",
         "a",
-        "test",
         "--cov=urllib3",
-        *session.posargs,
+        *(session.posargs or ("test/",)),
         env={"PYTHONWARNINGS": "always::DeprecationWarning"}
     )
     session.run("coverage", "xml")

--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -42,7 +42,13 @@ from ..util.ssl_ import (
     BaseSSLError,
 )
 from ..util.timeout import Timeout
-from ..util.url import get_host, Url, _normalize_host as normalize_host
+from ..util.url import (
+    get_host,
+    parse_url,
+    Url,
+    _normalize_host as normalize_host,
+    _encode_target,
+)
 from ..util.queue import LifoQueue
 
 try:
@@ -581,6 +587,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         if not isinstance(retries, Retry):
             retries = Retry.from_int(retries, default=self.retries, redirect=False)
+
+        # Ensure that the URL we're connecting to is properly encoded
+        if url.startswith("/"):
+            url = six.ensure_str(_encode_target(url))
+        else:
+            url = six.ensure_str(parse_url(url).url)
 
         conn = None
 

--- a/src/urllib3/fields.py
+++ b/src/urllib3/fields.py
@@ -47,7 +47,7 @@ def format_header_param_rfc2231(name, value):
         else:
             return result
 
-    if not six.PY3:  # Python 2:
+    if six.PY2:  # Python 2:
         value = value.encode("utf-8")
 
     # encode_rfc2231 accepts an encoded string and returns an ascii-encoded
@@ -55,7 +55,7 @@ def format_header_param_rfc2231(name, value):
     value = email.utils.encode_rfc2231(value, "utf-8")
     value = "%s*=%s" % (name, value)
 
-    if not six.PY3:  # Python 2:
+    if six.PY2:  # Python 2:
         value = value.decode("utf-8")
 
     return value

--- a/src/urllib3/filepost.py
+++ b/src/urllib3/filepost.py
@@ -17,7 +17,7 @@ def choose_boundary():
     Our embarrassingly-simple replacement for mimetools.choose_boundary.
     """
     boundary = binascii.hexlify(os.urandom(16))
-    if six.PY3:
+    if not six.PY2:
         boundary = boundary.decode("ascii")
     return boundary
 

--- a/src/urllib3/util/url.py
+++ b/src/urllib3/util/url.py
@@ -55,6 +55,7 @@ IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
 ZONE_ID_PAT = "(?:%25|%)(?:[" + UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
 IPV6_ADDRZ_PAT = r"\[" + IPV6_PAT + r"(?:" + ZONE_ID_PAT + r")?\]"
 REG_NAME_PAT = r"(?:[^\[\]%:/?#]|%[a-fA-F0-9]{2})*"
+TARGET_RE = re.compile(r"^(/[^?]*)(?:\?([^#]+))?(?:#(.*))?$")
 
 IPV4_RE = re.compile("^" + IPV4_PAT + "$")
 IPV6_RE = re.compile("^" + IPV6_PAT + "$")
@@ -316,6 +317,22 @@ def _idna_encode(name):
                 LocationParseError(u"Name '%s' is not a valid IDNA label" % name), None
             )
     return name.lower().encode("ascii")
+
+
+def _encode_target(target):
+    """Percent-encodes a request target so that there are no invalid characters"""
+    if not target.startswith("/"):
+        return target
+
+    path, query, fragment = TARGET_RE.match(target).groups()
+    target = _encode_invalid_chars(path, PATH_CHARS)
+    query = _encode_invalid_chars(query, QUERY_CHARS)
+    fragment = _encode_invalid_chars(fragment, FRAGMENT_CHARS)
+    if query is not None:
+        target += "?" + query
+    if fragment is not None:
+        target += "#" + target
+    return target
 
 
 def parse_url(url):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -62,7 +62,7 @@ def onlyPy2(test):
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.x to run".format(name=test.__name__)
-        if six.PY3:
+        if not six.PY2:
             pytest.skip(msg)
         return test(*args, **kwargs)
 
@@ -75,7 +75,7 @@ def onlyPy3(test):
     @functools.wraps(test)
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python3.x to run".format(name=test.__name__)
-        if not six.PY3:
+        if six.PY2:
             pytest.skip(msg)
         return test(*args, **kwargs)
 

--- a/test/appengine/conftest.py
+++ b/test/appengine/conftest.py
@@ -72,7 +72,7 @@ def sandbox(testbed):
 def pytest_ignore_collect(path, config):
     """Skip App Engine tests in python 3 or if no SDK is available."""
     if "appengine" in str(path):
-        if six.PY3:
+        if not six.PY2:
             return True
         if not os.environ.get("GAE_SDK_PATH"):
             return True

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -31,12 +31,14 @@ def teardown_module():
         pass
 
 
+# Currently TLSv1.3 doesn't work with SecureTransport despite
+# Apple previously documenting support. See:
+# https://github.com/python-trio/trio/issues/1165#issuecomment-526563135
 from ..with_dummyserver.test_https import (  # noqa: F401
     TestHTTPS,
     TestHTTPS_TLSv1,
     TestHTTPS_TLSv1_1,
     TestHTTPS_TLSv1_2,
-    TestHTTPS_TLSv1_3,
 )
 from ..with_dummyserver.test_socketlevel import (  # noqa: F401
     TestSNI,

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -666,6 +666,11 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with pytest.raises(MaxRetryError):
             pool.request("GET", "/test", retries=2)
 
+    def test_percent_encode_invalid_target_chars(self):
+        with HTTPConnectionPool(self.host, self.port) as pool:
+            r = pool.request("GET", "/echo_params?q=\r&k=\n \n")
+            assert r.data == b"[('k', '\\n \\n'), ('q', '\\r')]"
+
     def test_source_address(self):
         for addr, is_ipv6 in VALID_SOURCE_ADDRESSES:
             if is_ipv6 and not HAS_IPV6_AND_DNS:
@@ -682,7 +687,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             pool = HTTPConnectionPool(
                 self.host, self.port, source_address=addr, retries=False
             )
-            # FIXME: This assert flakes sometimes. Not sure why.
             with pytest.raises(NewConnectionError):
                 pool.request("GET", "/source_address?{0}".format(addr))
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -140,10 +140,12 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             ):
                 raise
         except ProtocolError as e:
-            # https://github.com/urllib3/urllib3/issues/1422
             if not (
                 "An existing connection was forcibly closed by the remote host"
                 in str(e)
+                # Python 3.7.4+
+                or "WSAECONNRESET" in str(e)  # Windows
+                or "EPIPE" in str(e)  # macOS
             ):
                 raise
 


### PR DESCRIPTION
I realized that some upstream tests are using context manager where we don't use them, probably because we removed a few addCleanup calls manually at some point? I'll try to fix that after the current round of merges.