### PR TITLE
Support async content preloading

### DIFF
--- a/src/urllib3/_async/connectionpool.py
+++ b/src/urllib3/_async/connectionpool.py
@@ -522,6 +522,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         timeout=_Default,
         pool_timeout=None,
         body_pos=None,
+        preload_content=True,
         **response_kw
     ):
         """
@@ -577,6 +578,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             Position to seek to in file-like body in the event of a retry or
             redirect. Typically this won't need to be set because urllib3 will
             auto-populate the value when needed.
+
+        :param preload_content:
+            If True, the response's body will be preloaded during construction.
 
         :param \\**response_kw:
             Additional parameters are passed to
@@ -641,6 +645,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             response = self.ResponseCls.from_base(
                 base_response, pool=self, retries=retries, **response_kw
             )
+            # If requested, preload the body.
+            if preload_content:
+                await response.preload_content()
 
             # Everything went great!
             clean_exit = True
@@ -706,6 +713,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 timeout=timeout,
                 pool_timeout=pool_timeout,
                 body_pos=body_pos,
+                preload_content=preload_content,
                 **response_kw
             )
 
@@ -744,6 +752,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 timeout=timeout,
                 pool_timeout=pool_timeout,
                 body_pos=body_pos,
+                preload_content=preload_content,
                 **response_kw
             )
 

--- a/src/urllib3/_async/response.py
+++ b/src/urllib3/_async/response.py
@@ -156,9 +156,6 @@ class HTTPResponse(io.IOBase):
 
     Extra parameters for behaviour not present in httplib.HTTPResponse:
 
-    :param preload_content:
-        If True, the response's body will be preloaded during construction.
-
     :param decode_content:
         If True, will attempt to decode the body based on the
         'content-encoding' header.
@@ -181,7 +178,6 @@ class HTTPResponse(io.IOBase):
         version=0,
         reason=None,
         strict=0,
-        preload_content=True,
         decode_content=True,
         original_response=None,
         pool=None,
@@ -221,9 +217,9 @@ class HTTPResponse(io.IOBase):
         self._pool = pool
         self._connection = connection
 
-        # If requested, preload the body.
-        if preload_content and not self._body:
-            self._body = self.read(decode_content=decode_content)
+    async def preload_content(self):
+        if not self._body:
+            self._body = await self.read(decode_content=self.decode_content)
 
     def get_redirect_location(self):
         """

--- a/test/with_dummyserver/async/test_poolmanager.py
+++ b/test/with_dummyserver/async/test_poolmanager.py
@@ -17,6 +17,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
                 fields={"target": "%s/" % self.base_url},
                 redirect=False,
             )
+
             assert r.status == 303
 
             r = await http.request(
@@ -26,4 +27,4 @@ class TestPoolManager(HTTPDummyServerTestCase):
             )
 
             assert r.status == 200
-            assert await r.read() == b"Dummy server!"
+            assert r.data == b"Dummy server!"


### PR DESCRIPTION
The idea here is just to make sure the existing way works, we don't refactor anything else.

We had to take the call to `read()` out of the constructor as we can't have await expressions there. This solution works since `HTTPConnectionPool.urlopen()` is the only place where responses are
instantiated. (App Engine does not count as we'll remove it later.)