### PR TITLE
Sniff async backends using sniffio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,9 @@ package_dir =
     = src
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*, <4
-install_requires = h11 >= 0.8.0
+install_requires =
+    h11 >= 0.8.0
+    sniffio; python_version>='3.6'
 
 [options.packages.find]
 where = src

--- a/src/urllib3/_backends/_loader.py
+++ b/src/urllib3/_backends/_loader.py
@@ -50,7 +50,12 @@ def backend_directory():
 
 def normalize_backend(backend, async_mode):
     if backend is None:
-        backend = Backend(name="sync")  # sync backend is the default
+        if not async_mode:
+            backend = Backend(name="sync")
+        else:
+            import sniffio
+
+            backend = Backend(name=sniffio.current_async_library())
     elif not isinstance(backend, Backend):
         backend = Backend(name=backend)
 

--- a/test/async/test_backends.py
+++ b/test/async/test_backends.py
@@ -1,0 +1,10 @@
+import trio
+from urllib3._backends._loader import normalize_backend
+
+
+def test_sniff_async():
+    async def main():
+        backend = normalize_backend(None, async_mode=True)
+        assert backend.name == "trio"
+
+    trio.run(main)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,4 +2,4 @@ import sys
 
 # We support Python 3.6+ for async code
 if sys.version_info[:2] < (3, 6):
-    collect_ignore_glob = ["*/async/*.py", "with_dummyserver/async/*.py"]
+    collect_ignore_glob = ["async/*.py", "with_dummyserver/async/*.py"]

--- a/test/with_dummyserver/async/test_poolmanager.py
+++ b/test/with_dummyserver/async/test_poolmanager.py
@@ -10,7 +10,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
         self.base_url_alt = "http://%s:%d" % (self.host_alt, self.port)
 
     async def test_redirect(self):
-        with AsyncPoolManager(backend="trio") as http:
+        with AsyncPoolManager() as http:
             r = await http.request(
                 "GET",
                 "%s/redirect" % self.base_url,


### PR DESCRIPTION
This will result in a better user experience, and also helps to reduce the differences between the sync and async tests, as you can see in  test/with_dummyserver/async/test_poolmanager.py.